### PR TITLE
Fixes related to file size computation

### DIFF
--- a/classes/class-seriously-simple-podcasting.php
+++ b/classes/class-seriously-simple-podcasting.php
@@ -488,8 +488,12 @@ class SeriouslySimplePodcasting {
 					$duration = get_post_meta( $id , 'duration' , true );
 					$size = get_post_meta( $id , 'filesize' , true );
 					if( ! $size || strlen( $size ) == 0 || $size == '' ) {
-						$size = $this->get_file_size( $file );
-						$size = $size['formatted'];
+						$filesize = $this->get_file_size( $file );
+						$size = $filesize['formatted'];
+
+						// Update so we don't do this again unless necessary
+						update_post_meta( $id , 'filesize' , $filesize['formatted'] );
+						update_post_meta( $id, 'filesize_raw' , $filesize['raw'] );
 					}
 
 					$meta = '';

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -206,8 +206,12 @@ echo '<?xml version="1.0" encoding="' . get_option('blog_charset') . '"?'.'>'; ?
 		// File size
 		$size = get_post_meta( get_the_ID() , 'filesize_raw' , true );
 		if( ! $size || strlen( $size ) == 0 || $size == '' ) {
-			$size = $ss_podcasting->get_file_size( $enclosure );
-			$size = esc_html( $size['raw'] );
+			$filesize = $ss_podcasting->get_file_size( $enclosure );
+			$size = esc_html( $filesize['raw'] );
+
+			// Update so we don't do this again unless necessary
+			update_post_meta( get_the_ID() , 'filesize' , $filesize['formatted'] );
+			update_post_meta( get_the_ID(), 'filesize_raw' , $filesize['raw'] );
 		}
 
 		if( ! $size || strlen( $size ) == 0 || $size == '' ) {


### PR DESCRIPTION
Hi there - I made some changes that should make get_file_size more reliable and avoid it being called redundantly when it had for some reason not succeeded at some point.

Hopefully the fixes are obvious from the comments, but let me know if you have questions. The only aspect I think you might want to question is whether my chosen default timeout of 10 seconds (as opposed to WordPress's default 5) is appropriate or not. Since I was running into timeouts often with Libsyn (a popular podcasting host), I thought it would be appropriate to default to higher for more compatibility with many folks' podcasts.
