### PR TITLE
Front-end should use home_url() instead of site_url()

### DIFF
--- a/classes/class-seriously-simple-podcasting-admin.php
+++ b/classes/class-seriously-simple-podcasting-admin.php
@@ -6,7 +6,7 @@ class SeriouslySimplePodcasting_Admin {
 	private $file;
 	private $assets_dir;
 	private $assets_url;
-	private $site_url;
+	private $home_url;
 	private $token;
 
 	public function __construct( $file ) {
@@ -14,7 +14,7 @@ class SeriouslySimplePodcasting_Admin {
 		$this->file = $file;
 		$this->assets_dir = trailingslashit( $this->dir ) . 'assets';
 		$this->assets_url = esc_url( trailingslashit( plugins_url( '/assets/', $file ) ) );
-		$this->site_url = trailingslashit( site_url() );
+		$this->home_url = trailingslashit( home_url() );
 		$this->token = 'podcast';
 
 		// Register podcast settings
@@ -210,7 +210,7 @@ class SeriouslySimplePodcasting_Admin {
 			$data = $option;
 		}
 
-		$default_url = $this->site_url . '?post_type=podcast';
+		$default_url = $this->home_url . '?post_type=podcast';
 
 		echo '<input id="slug" type="text" name="ss_podcasting_slug" value="' . $data . '"/>
 				<label for="slug"><span class="description">' . sprintf( __( 'Provide a custom URL slug for the podcast archive and single pages. You must re-save your %1$spermalinks%2$s after changing this setting. No matter what you put here your podcast will always be visible at %3$s.' , 'ss-podcasting' ) , '<a href="' . esc_attr( 'options-permalink.php' ) . '">' , '</a>' , '<a href="' . esc_url( $default_url ) . '">' . $default_url . '</a>' ) . '</span></label>';
@@ -554,18 +554,18 @@ class SeriouslySimplePodcasting_Admin {
 	}
 
 	public function feed_standard() {
-		$rss_url = $this->site_url . '?feed=podcast';
+		$rss_url = $this->home_url . '?feed=podcast';
 		echo $rss_url;
 	}
 
 	public function feed_standard_series() {
-		$rss_url = $this->site_url . '?feed=podcast&podcast_series=series-slug';
+		$rss_url = $this->home_url . '?feed=podcast&podcast_series=series-slug';
 		echo $rss_url;
 	}
 
 	public function podcast_url() {
 
-		$podcast_url = $this->site_url;
+		$podcast_url = $this->home_url;
 
 		$slug = get_option('ss_podcasting_slug');
 		if( $slug && strlen( $slug ) > 0 && $slug != '' ) {
@@ -580,7 +580,7 @@ class SeriouslySimplePodcasting_Admin {
 
 	public function social_sharing() {
 
-		$share_url = $this->site_url;
+		$share_url = $this->home_url;
 		$custom_title = get_option('ss_podcasting_data_title');
 		$share_title = sprintf( __( 'Podcast on %s', 'ss-podcasting' ), get_bloginfo( 'name' ) );
 		if( $custom_title && strlen( $custom_title ) > 0 && $custom_title != '' ) {

--- a/classes/class-seriously-simple-podcasting.php
+++ b/classes/class-seriously-simple-podcasting.php
@@ -8,6 +8,7 @@ class SeriouslySimplePodcasting {
 	private $assets_url;
 	private $template_path;
 	private $token;
+	private $home_url;
 
 	public function __construct( $file ) {
 		$this->dir = dirname( $file );
@@ -15,7 +16,6 @@ class SeriouslySimplePodcasting {
 		$this->assets_dir = trailingslashit( $this->dir ) . 'assets';
 		$this->assets_url = esc_url( trailingslashit( plugins_url( '/assets/', $file ) ) );
 		$this->template_path = trailingslashit( $this->dir ) . 'templates/';
-		$this->site_url = trailingslashit( site_url() );
 		$this->home_url = trailingslashit( home_url() );
 		$this->token = 'podcast';
 
@@ -216,7 +216,7 @@ class SeriouslySimplePodcasting {
             case 'series_feed_url':
             	$series = get_term( $term_id, 'series' );
             	$series_slug = $series->slug;
-            	$feed_url = $this->site_url . '?feed=podcast&podcast_series=' . $series_slug;
+            	$feed_url = $this->home_url . '?feed=podcast&podcast_series=' . $series_slug;
                 $column_data = '<a href="' . $feed_url . '" target="_blank">' . $feed_url . '</a>';
             break;
         }
@@ -454,7 +454,7 @@ class SeriouslySimplePodcasting {
 	public function rss_meta_tag() {
 
 		$custom_feed_url = get_option('ss_podcasting_feed_url');
-		$feed_url = $this->site_url . '?feed=podcast';
+		$feed_url = $this->home_url . '?feed=podcast';
 		if( $custom_feed_url && strlen( $custom_feed_url ) > 0 && $custom_feed_url != '' ) {
 			$feed_url = $custom_feed_url;
 		}
@@ -468,7 +468,7 @@ class SeriouslySimplePodcasting {
 
 		$file = $this->get_enclosure( $episode );
 
-		$link = add_query_arg( array( 'podcast_episode' => $file ), $this->site_url );
+		$link = add_query_arg( array( 'podcast_episode' => $file ), $this->home_url );
 
 		return $link;
 	}
@@ -569,7 +569,7 @@ class SeriouslySimplePodcasting {
 
 			// Identify file by root path and not URL (required for getID3 class)
 			$site_root = trailingslashit( ABSPATH );
-			$file = str_replace( $this->site_url, $site_root, $file );
+			$file = str_replace( $this->home_url, $site_root, $file );
 
 			$info = $getid3->analyze( $file );
 

--- a/templates/archive-podcast.php
+++ b/templates/archive-podcast.php
@@ -21,7 +21,7 @@ get_header(); ?>
 				</header>
 
 				<?php
-				$feed_url = trailingslashit( get_site_url() ) . '?feed=podcast';
+				$feed_url = trailingslashit( home_url() ) . '?feed=podcast';
 				$custom_feed_url = get_option('ss_podcasting_feed_url');
 				if( $custom_feed_url && strlen( $custom_feed_url ) > 0 && $custom_feed_url != '' ) {
 					$feed_url = $custom_feed_url;


### PR DESCRIPTION
See difference between [home_url()](http://codex.wordpress.org/Function_Reference/home_url) and [site_url()](http://codex.wordpress.org/Function_Reference/site_url), including some discussion on [this StackExchange question](http://wordpress.stackexchange.com/questions/20294/whats-the-difference-between-home-url-and-site-url). This is important when [giving WordPress its own directory](http://codex.wordpress.org/Giving_WordPress_Its_Own_Directory) as site_url() will point to the WordPress install directory, with home_url() pointing to the front-end. Currently this plugin doesn't work on our sites that have WordPress in its own directory, since it uses site_url() for everything and WordPress doesn't know what do with these URLs.
