### PR TITLE
Single Podcast template: change the way the content is called

### DIFF
--- a/templates/single-podcast.php
+++ b/templates/single-podcast.php
@@ -45,7 +45,7 @@ $post = get_post( $id );
 					</a>
 				<?php } ?>
 
-				<?php echo $ss_podcasting->content_meta_data( wpautop( $post->post_content ) ); ?>
+				<?php the_content(); ?>
 
 			<section>
 


### PR DESCRIPTION
Since `content_meta_data` is already hooked into `the_content`, wouldn't it be possible to directly call `the_content` into the template?
This would allow third-party plugins to hook elements into the single podcast template.

More discussion about this here:
http://wordpress.org/support/topic/ssp-jetpack-how-to-get-g-bar-at-the-bottom-of-podcast
