### PR TITLE
#507 - Add "Download" Text to HTML5 Player

### DIFF
--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -456,7 +456,7 @@ class Frontend_Controller extends Controller {
 										<div class="ssp-media-player">
 											<div class="ssp-custom-player-controls">
 												<div class="ssp-play-pause" id="ssp-play-pause">
-													<span class="ssp-icon ssp-icon-play_icon">&nbsp;</span>
+													<span class="ssp-icon ssp-icon-play_icon"><span class="screen-reader-text">Play/Pause Episode</span></span>
 												</div>
 												<div class="ssp-wave-form">
 													<div class="ssp-inner">
@@ -470,7 +470,7 @@ class Frontend_Controller extends Controller {
 													<div class="ssp-volume">
 														<div class="ssp-back-thirty-container">
 															<div class="ssp-back-thirty-control" id="ssp-back-thirty">
-																<i class="ssp-icon icon-replay">&nbsp;</i>
+																<i class="ssp-icon icon-replay"><span class="screen-reader-text">Rewind 30 Seconds</span></i>
 															</div>
 														</div>
 														<div class="ssp-playback-speed-label-container">
@@ -480,7 +480,7 @@ class Frontend_Controller extends Controller {
 														</div>
 														<div class="ssp-download-container">
 															<div class="ssp-download-control">
-																<a class="ssp-episode-download" href="<?php echo $this->get_episode_download_link( $episode_id, 'download' ); ?>" target="_blank"><i class="ssp-icon icon-cloud-download">&nbsp;</i></a>
+																<a class="ssp-episode-download" href="<?php echo $this->get_episode_download_link( $episode_id, 'download' ); ?>" target="_blank"><i class="ssp-icon icon-cloud-download"><span class="screen-reader-text">Download Episode</span></i></a>
 															</div>
 														</div>
 													</div>


### PR DESCRIPTION
Added "Play/Pause", "Rewind 30 Seconds", and "Download Epsiode" anchor text for elements that are using icons for better accessibility with screen readers.

(Also I don't think I borked making this pull request, but if I did, I apologize!)