### PR TITLE
Release/2.5.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ GitHub is for *bug reports and contributions only* - if you have a support quest
 
 * Fork the repository on GitHub.
 * Clone the forked repository to your local development environment
-* Run `npm install`, which will install any npm and composer dependancies, as well as build any block editor assets
+* Run `npm install`, which will install any npm and composer dependencies, as well as build any block editor assets
 * Define the `SCRIPT_DEBUG` constant in your wp-config.php to use the development versions of any JavaScript and CSS assets
 * Make the changes to your forked repository.
   * **Ensure you stick to the [WordPress Coding Standards](http://make.wordpress.org/core/handbook/coding-standards/) for all languages.**

--- a/index.php
+++ b/index.php
@@ -1,3 +1,3 @@
 <?php
 
-// Slience is golden
+// Silence is golden

--- a/php/classes/blocks/class-castos-blocks.php
+++ b/php/classes/blocks/class-castos-blocks.php
@@ -64,7 +64,7 @@ class Castos_Blocks extends Controller {
 
 			return;
 		}
-		include SSP_PLUGIN_PATH . 'build/index.asset.php';
+		$this->asset_file = include SSP_PLUGIN_PATH . 'build/index.asset.php';
 		add_action( 'init', array( $this, 'register_castos_blocks' ) );
 	}
 

--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -1401,7 +1401,7 @@ class Frontend_Controller extends Controller {
 	 * @param  array   $content_items Ordered array of content items to display
 	 * @return string                 HTML of episode with specified content items
 	 */
-	public function podcast_episode ( $episode_id = 0, $content_items = array( 'title', 'player', 'details' ), $context = '', $style = 'mini' ) {
+	public function podcast_episode ( $episode_id = 0, $content_items = array( 'title', 'player', 'details' ), $context = '', $style = 'standard' ) {
 		global $post, $episode_context;
 
 		if ( ! $episode_id || ! is_array( $content_items ) || empty( $content_items ) ) {

--- a/php/classes/controllers/class-settings-controller.php
+++ b/php/classes/controllers/class-settings-controller.php
@@ -154,7 +154,7 @@ class Settings_Controller extends Controller {
 	 * Show the upgrade page
 	 */
 	public function show_upgrade_page() {
-		$ssp_redirect = ( isset( $_GET['ssp_redirect'] ) ? filter_var( $_GET['ssp_redirect'], FILTER_SANITIZE_STRING ) : '' );https://psykrotek.co.za/wp-admin/admin.php?page=jetpack#/dashboard
+		$ssp_redirect = ( isset( $_GET['ssp_redirect'] ) ? filter_var( $_GET['ssp_redirect'], FILTER_SANITIZE_STRING ) : '' );
 		$ssp_dismiss_url = add_query_arg( array( 'ssp_dismiss_upgrade' => 'dismiss', 'ssp_redirect' => rawurlencode( $ssp_redirect ) ), admin_url( 'index.php' ) );
 		include( $this->template_path . DIRECTORY_SEPARATOR . 'settings-upgrade-page.php' );
 	}

--- a/php/classes/handlers/class-options-handler.php
+++ b/php/classes/handlers/class-options-handler.php
@@ -139,8 +139,12 @@ class Options_Handler {
 	public function get_subscribe_urls( $episode_id, $context ) {
 		$terms             = get_the_terms( $episode_id, 'series' );
 		$subscribe_options = get_option( 'ss_podcasting_subscribe_options', array() );
+		$subscribe_array   = array();
 
-		$subscribe_array = array();
+		if ( ! is_array( $subscribe_options ) ) {
+			return apply_filters( 'ssp_episode_subscribe_details', $subscribe_array, $episode_id, $context );
+		}
+
 		foreach ( $subscribe_options as $option_key ) {
 			if ( ! isset( $this->available_subscribe_options[ $option_key ] ) ) {
 				continue;

--- a/php/classes/shortcodes/class-player.php
+++ b/php/classes/shortcodes/class-player.php
@@ -45,7 +45,7 @@ class Player {
 			$file = $ss_podcasting->get_episode_download_link( $episode_id );
 		}
 
-		$player_style = (string) get_option( 'ss_podcasting_player_style', '' );
+		$player_style = (string) get_option( 'ss_podcasting_player_style', 'standard' );
 
 		// Make sure we return and don't echo.
 		$args['echo'] = false;

--- a/php/classes/shortcodes/class-podcast-episode.php
+++ b/php/classes/shortcodes/class-podcast-episode.php
@@ -26,13 +26,11 @@ class Podcast_Episode {
 
 		global $ss_podcasting;
 
-		$player_style = get_option( 'ss_podcasting_player_style', 'standard' );
-
 		$atts = shortcode_atts(
 			array(
 				'episode' => 0,
 				'content' => 'title,player,details',
-				'style'   => $player_style,
+				'style'   => 'standard',
 			),
 			$params,
 			'podcast_episode'

--- a/php/classes/shortcodes/class-podcast-playlist.php
+++ b/php/classes/shortcodes/class-podcast-playlist.php
@@ -44,7 +44,7 @@ class Podcast_Playlist {
 				'include'      => '',
 				'exclude'      => '',
 				'style'        => 'light',
-				'player_style' => 'mini',
+				'player_style' => 'standard',
 				'tracklist'    => true,
 				'tracknumbers' => true,
 				'images'       => true,
@@ -181,7 +181,7 @@ class Podcast_Playlist {
 					$track['thumb'] = '';
 				}
 			}
-			
+
 			// Allow dynamic filtering of track data
 			$track = apply_filters( 'ssp_podcast_playlist_track_data', $track, $episode );
 
@@ -198,7 +198,7 @@ class Podcast_Playlist {
 
 		ob_start();
 
-		$player_style = 'mini';
+		$player_style = 'standard';
 
 		// @todo clean this mess up
 

--- a/php/classes/widgets/class-single-episode.php
+++ b/php/classes/widgets/class-single-episode.php
@@ -124,7 +124,7 @@ class Single_Episode extends WP_Widget {
 		}
 
 		// Get episode markup
-		$html = $ss_podcasting->podcast_episode( $episode_id, $content_items, 'widget', 'mini' );
+		$html = $ss_podcasting->podcast_episode( $episode_id, $content_items, 'widget', 'standard' );
 
 		if ( ! $html ) {
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -159,6 +159,13 @@ You can find complete user and developer documentation (along with the FAQs) on 
 
 == Changelog ==
 
+= 2.5.2 =
+* 2020-12-15
+* UPDATE SUMMARY: Bug fixes for the 2.5 release
+* [FIX] Fixes a bug where specific widgets and shortcodes were not rendering the player
+* [FIX] Fixes a bug where leaving all Distribution Items unchecked causes a PHP error
+* [FIX] Fixes a bug where loading the blocks causes a PHP notice
+
 = 2.5.1 =
 * 2020-12-08
 * UPDATE SUMMARY: Podcast Episode bug fixes for the 2.5 release

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: podcast, audio, video, vodcast, rss, mp3, mp4, feed, itunes, podcasting, m
 Requires at least: 4.4
 Tested up to: 5.5.3
 Requires PHP: 5.6
-Stable tag: 2.5.1
+Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -160,11 +160,12 @@ You can find complete user and developer documentation (along with the FAQs) on 
 == Changelog ==
 
 = 2.5.2 =
-* 2020-12-15
+* 2020-12-17
 * UPDATE SUMMARY: Bug fixes for the 2.5 release
 * [FIX] Fixes a bug where specific widgets and shortcodes were not rendering the player
 * [FIX] Fixes a bug where leaving all Distribution Items unchecked causes a PHP error
-* [FIX] Fixes a bug where loading the blocks causes a PHP notice
+* [FIX] Fixes a bug where loading the Block Editor assets causes a PHP notice
+* [FIX] Fixes various spelling errors in the plugin (props [ihatehandles](https://profiles.wordpress.org/ihatehandles))
 
 = 2.5.1 =
 * 2020-12-08

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 2.5.1
+ * Version: 2.5.2-beta
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -32,7 +32,7 @@ use SeriouslySimplePodcasting\Rest\Rest_Api_Controller;
 use SeriouslySimplePodcasting\Controllers\Players_Controller;
 use SeriouslySimplePodcasting\Integrations\Elementor\Elementor_Widgets;
 
-define( 'SSP_VERSION', '2.5.1' );
+define( 'SSP_VERSION', '2.5.2-beta' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 2.5.2-beta
+ * Version: 2.5.2
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -32,7 +32,7 @@ use SeriouslySimplePodcasting\Rest\Rest_Api_Controller;
 use SeriouslySimplePodcasting\Controllers\Players_Controller;
 use SeriouslySimplePodcasting\Integrations\Elementor\Elementor_Widgets;
 
-define( 'SSP_VERSION', '2.5.2-beta' );
+define( 'SSP_VERSION', '2.5.2' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 

--- a/templates/settings-upgrade-page.php
+++ b/templates/settings-upgrade-page.php
@@ -117,7 +117,7 @@
 					<li>Automated Transcripts for all your episodes</li>
 					<li>Safe, secure file storage on a robust hosting platform</li>
 				</ul>
-				<p>Every account comes with a Free 14 day Trial</p>
+				<p>Every account comes with a Free 14-day Trial</p>
 				<br>
 				<div class="signup">
 					<a target="_blank" class='button' href="https://castos.com/ssp/?utm_source=plugin&utm_medium=welcome&utm_campaign=signup_link">Sign Up Today</a>


### PR DESCRIPTION
## UPDATE SUMMARY: Bug fixes for the 2.5 release
* [FIX] Fixes a bug where specific widgets and shortcodes were not rendering the player
* [FIX] Fixes a bug where leaving all Distribution Items unchecked causes a PHP error
* [FIX] Fixes a bug where loading the Block Editor assets causes a PHP notice
* [FIX] Fixes various spelling errors in the plugin (props [ihatehandles](https://profiles.wordpress.org/ihatehandles))
