### PR TITLE
Hyphenate trial duration

### DIFF
--- a/templates/settings-upgrade-page.php
+++ b/templates/settings-upgrade-page.php
@@ -117,7 +117,7 @@
 					<li>Automated Transcripts for all your episodes</li>
 					<li>Safe, secure file storage on a robust hosting platform</li>
 				</ul>
-				<p>Every account comes with a Free 14 day Trial</p>
+				<p>Every account comes with a Free 14-day Trial</p>
 				<br>
 				<div class="signup">
 					<a target="_blank" class='button' href="https://castos.com/ssp/?utm_source=plugin&utm_medium=welcome&utm_campaign=signup_link">Sign Up Today</a>


### PR DESCRIPTION
Not a problem if you want to keep it as it currently is. I know Algolia use this https://www.algolia.com/users/sign_up, but the hyphenated form is more common.

Time allowing, I would also have loved to fix the layout on this page. The text gets clipped on the far right there:
![image](https://user-images.githubusercontent.com/958800/102402200-1a8a4380-3fed-11eb-96e1-8cb8eac25615.png)
