### PR TITLE
Fix: episode file url

### DIFF
--- a/php/classes/controllers/class-admin-controller.php
+++ b/php/classes/controllers/class-admin-controller.php
@@ -67,6 +67,8 @@ class Admin_Controller extends Controller {
 
 		$this->feed_controller = new Feed_Controller( $this->file, $this->version );
 
+		$this->episode_controller = new Episode_Controller( $this->file, $this->version );
+
 		$this->logger = new Log_Helper();
 
 		if ( is_admin() ) {
@@ -492,7 +494,7 @@ HTML;
 				'type'         => 'string',
 				'description'  => isset( $data['meta_description'] ) ? $data['meta_description'] : "",
 				'single'       => true,
-				'show_in_rest' => true,
+				'show_in_rest' => isset( $data['show_in_rest'] ) ? $data['show_in_rest'] : true,
 			);
 
 			register_meta( 'post', $key, $args );
@@ -970,6 +972,9 @@ HTML;
 			'default'          => '',
 			'section'          => 'info',
 			'meta_description' => __( 'The full URL for the podcast episode media file.', 'seriously-simple-podcasting' ),
+			'show_in_rest'     => array(
+				'prepare_callback' => array( $this, 'prepare_audio_file' ),
+			),
 		);
 
 		//
@@ -1093,6 +1098,23 @@ HTML;
 		}
 
 		return apply_filters( 'ssp_episode_fields', $fields );
+	}
+
+	/**
+	 * Callback to modify meta audio file value for REST.
+	 *
+	 * @param $value
+	 *
+	 * @return string
+	 */
+	public function prepare_audio_file( $value ) {
+		global $post;
+
+		if ( ! is_a( $post, 'WP_Post' ) ) {
+			return $value;
+		}
+
+		return $this->episode_controller->get_audio_file( $post->ID );
 	}
 
 	/**

--- a/php/classes/controllers/class-admin-controller.php
+++ b/php/classes/controllers/class-admin-controller.php
@@ -494,7 +494,7 @@ HTML;
 				'type'         => 'string',
 				'description'  => isset( $data['meta_description'] ) ? $data['meta_description'] : "",
 				'single'       => true,
-				'show_in_rest' => isset( $data['show_in_rest'] ) ? $data['show_in_rest'] : true,
+				'show_in_rest' => true,
 			);
 
 			register_meta( 'post', $key, $args );
@@ -972,9 +972,6 @@ HTML;
 			'default'          => '',
 			'section'          => 'info',
 			'meta_description' => __( 'The full URL for the podcast episode media file.', 'seriously-simple-podcasting' ),
-			'show_in_rest'     => array(
-				'prepare_callback' => array( $this, 'prepare_audio_file' ),
-			),
 		);
 
 		//
@@ -1098,23 +1095,6 @@ HTML;
 		}
 
 		return apply_filters( 'ssp_episode_fields', $fields );
-	}
-
-	/**
-	 * Callback to modify meta audio file value for REST.
-	 *
-	 * @param $value
-	 *
-	 * @return string
-	 */
-	public function prepare_audio_file( $value ) {
-		global $post;
-
-		if ( ! is_a( $post, 'WP_Post' ) ) {
-			return $value;
-		}
-
-		return $this->episode_controller->get_audio_file( $post->ID );
 	}
 
 	/**

--- a/php/classes/controllers/class-admin-controller.php
+++ b/php/classes/controllers/class-admin-controller.php
@@ -67,8 +67,6 @@ class Admin_Controller extends Controller {
 
 		$this->feed_controller = new Feed_Controller( $this->file, $this->version );
 
-		$this->episode_controller = new Episode_Controller( $this->file, $this->version );
-
 		$this->logger = new Log_Helper();
 
 		if ( is_admin() ) {

--- a/php/classes/controllers/class-episode-controller.php
+++ b/php/classes/controllers/class-episode-controller.php
@@ -90,13 +90,13 @@ class Episode_Controller extends Controller {
 	}
 
 	/**
-	 * Get audio file for episode.
+	 * Get player link for episode.
 	 *
 	 * @param int $episode_id
 	 *
 	 * @return string
 	 */
-	public function get_audio_file( $episode_id ) {
+	public function get_episode_player_link( $episode_id ) {
 		$file = $this->get_enclosure( $episode_id );
 		if ( get_option( 'permalink_structure' ) ) {
 			$file = $this->get_episode_download_link( $episode_id );

--- a/php/classes/controllers/class-episode-controller.php
+++ b/php/classes/controllers/class-episode-controller.php
@@ -97,10 +97,7 @@ class Episode_Controller extends Controller {
 	 * @return string
 	 */
 	public function get_episode_player_link( $episode_id ) {
-		$file = $this->get_enclosure( $episode_id );
-		if ( get_option( 'permalink_structure' ) ) {
-			$file = $this->get_episode_download_link( $episode_id );
-		}
+		$file = $this->get_episode_download_link( $episode_id );
 
 		// Switch to podcast player URL
 		$file = str_replace( 'podcast-download', 'podcast-player', $file );

--- a/php/classes/controllers/class-episode-controller.php
+++ b/php/classes/controllers/class-episode-controller.php
@@ -90,6 +90,25 @@ class Episode_Controller extends Controller {
 	}
 
 	/**
+	 * Get audio file for episode.
+	 *
+	 * @param int $episode_id
+	 *
+	 * @return string
+	 */
+	public function get_audio_file( $episode_id ) {
+		$file = $this->get_enclosure( $episode_id );
+		if ( get_option( 'permalink_structure' ) ) {
+			$file = $this->get_episode_download_link( $episode_id );
+		}
+
+		// Switch to podcast player URL
+		$file = str_replace( 'podcast-download', 'podcast-player', $file );
+
+		return $file;
+	}
+
+	/**
 	 * Returns the no album art image
 	 *
 	 * @return array

--- a/php/classes/controllers/class-players-controller.php
+++ b/php/classes/controllers/class-players-controller.php
@@ -75,7 +75,7 @@ class Players_Controller extends Controller {
 		$episode          = get_post( $id );
 		$episode_duration = get_post_meta( $id, 'duration', true );
 		$episode_url      = get_post_permalink( $id );
-		$audio_file       = $this->episode_controller->get_audio_file( $id );
+		$audio_file       = $this->episode_controller->get_episode_player_link( $id );
 		$album_art        = $this->episode_controller->get_album_art( $id );
 		$podcast_title    = get_option( 'ss_podcasting_data_title' );
 		$feed_url         = $this->episode_repository->get_feed_url( $id );
@@ -155,7 +155,7 @@ class Players_Controller extends Controller {
 		 * If the id passed is empty or 0, get_post will return the current post
 		 */
 		$episode  = get_post( $id );
-		$src_file = $this->episode_controller->get_audio_file( $id );
+		$src_file = $this->episode_controller->get_episode_player_link( $id );
 		$params   = array(
 			'src'     => $src_file,
 			'preload' => 'none',

--- a/php/classes/controllers/class-players-controller.php
+++ b/php/classes/controllers/class-players-controller.php
@@ -75,7 +75,7 @@ class Players_Controller extends Controller {
 		$episode          = get_post( $id );
 		$episode_duration = get_post_meta( $id, 'duration', true );
 		$episode_url      = get_post_permalink( $id );
-		$audio_file       = get_post_meta( $id, 'audio_file', true );
+		$audio_file       = $this->episode_controller->get_audio_file( $id );
 		$album_art        = $this->episode_controller->get_album_art( $id );
 		$podcast_title    = get_option( 'ss_podcasting_data_title' );
 		$feed_url         = $this->episode_repository->get_feed_url( $id );
@@ -155,7 +155,7 @@ class Players_Controller extends Controller {
 		 * If the id passed is empty or 0, get_post will return the current post
 		 */
 		$episode  = get_post( $id );
-		$src_file = get_post_meta( $episode->ID, 'audio_file', true );
+		$src_file = $this->episode_controller->get_audio_file( $id );
 		$params   = array(
 			'src'     => $src_file,
 			'preload' => 'none',

--- a/php/classes/rest/class-rest-api-controller.php
+++ b/php/classes/rest/class-rest-api-controller.php
@@ -214,7 +214,7 @@ class Rest_Api_Controller {
 	public function get_episode_audio_player() {
 		$podcast_id = ( isset( $_GET['ssp_podcast_id'] ) ? filter_var( $_GET['ssp_podcast_id'], FILTER_SANITIZE_STRING ) : '' );
 		global $ss_podcasting;
-		$file   = $ss_podcasting->episode_controller->get_enclosure( $podcast_id );
+		$file   = $ss_podcasting->episode_controller->get_audio_file( $podcast_id );
 		$params = array( 'src' => $file, 'preload' => 'none' );
 
 		return array(
@@ -420,7 +420,7 @@ class Rest_Api_Controller {
 				return;
 			}
 			global $ss_podcasting;
-			$file   = $ss_podcasting->episode_controller->get_enclosure( $object['id'] );
+			$file   = $ss_podcasting->episode_controller->get_audio_file( $object['id'] );
 			$params = array( 'src' => $file, 'preload' => 'none' );
 			return wp_audio_shortcode( $params );
 		}

--- a/src/components/EditCastosPlayer.js
+++ b/src/components/EditCastosPlayer.js
@@ -62,7 +62,7 @@ class EditCastosPlayer extends Component {
 				const episode = {
 					episodeId: episodeId,
 					episodeImage: post[0].episode_player_image,
-					episodeFileUrl: post[0].meta.audio_file,
+					episodeFileUrl: post[0].player_link,
 					episodeTitle: post[0].title.rendered,
 					episodeDuration: post[0].meta.duration,
 					episodeDownloadUrl: post[0].download_link,

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -18,7 +18,7 @@ class Player extends Component {
 				<CastosPlayer
 					className={className}
 					episodeImage={post.episode_player_image}
-					episodeFileUrl={post.meta.audio_file}
+					episodeFileUrl={post.player_link}
 					episodeTitle={post.title.rendered}
 					episodeDuration={post.meta.duration}
 					episodeDownloadUrl={post.download_link}


### PR DESCRIPTION
Closes #573, and also fixes the file URL for all other instances of the media player.

The reason why version 2.4.2 works for inline media player is probably because of this  line https://github.com/CastosHQ/Seriously-Simple-Podcasting/blob/90d707577642790ae754fd3db865bba884b024ec/php/classes/controllers/class-frontend-controller.php#L438

