### PR TITLE
Issue #572: Improving the podcast trash and podcast duplicate process

### DIFF
--- a/php/classes/controllers/class-admin-controller.php
+++ b/php/classes/controllers/class-admin-controller.php
@@ -119,7 +119,6 @@ class Admin_Controller extends Controller {
 			// Update podcast details to Castos when a post is updated or saved
 			add_action( 'post_updated', array( $this, 'update_podcast_details' ), 10, 2 );
 			add_action( 'save_post', array( $this, 'update_podcast_details' ), 10, 2 );
-			add_action( 'untrashed_post', array( $this, 'untrashed_post' ) );
 
 			// Episode edit screen.
 			add_filter( 'enter_title_here', array( $this, 'enter_title_here' ) );
@@ -1517,17 +1516,6 @@ HTML;
 	}
 
 	/**
-	 * Untrashed post actions
-	 *
-	 * @param int $id POST ID
-	 *
-	 * @return void
-	 */
-	public function untrashed_post( $id ) {
-		$this->update_podcast_details( $id, get_post( $id ) );
-	}
-
-	/**
 	 * Send the podcast details to Castos
 	 *
 	 * @param int $id
@@ -1605,14 +1593,6 @@ HTML;
 	 * @param $post_id
 	 */
 	public function delete_post( $post_id ) {
-
-		/**
-		 * Don't trigger this if we're not connected to Podcast Motor
-		 */
-		if ( ! ssp_is_connected_to_castos() ) {
-			return;
-		}
-
 		$post = get_post( $post_id );
 
 		/**
@@ -1622,7 +1602,18 @@ HTML;
 			return;
 		}
 
+		delete_post_meta( $post_id, 'podmotor_file_id' );
+		delete_post_meta( $post_id, 'podmotor_episode_id' );
+
+		/**
+		 * Don't trigger this if we're not connected to Podcast Motor
+		 */
+		if ( ! ssp_is_connected_to_castos() ) {
+			return;
+		}
+
 		$castos_handler = new Castos_Handler();
+
 		$castos_handler->delete_podcast( $post );
 	}
 

--- a/php/classes/handlers/class-castos-handler.php
+++ b/php/classes/handlers/class-castos-handler.php
@@ -410,9 +410,22 @@ class Castos_Handler {
 			)
 		);
 
-		delete_post_meta( $post->ID, 'podmotor_episode_id' );
-
 		$this->logger->log( 'Delete Podcast api_response', $api_response );
+
+		if ( is_wp_error( $api_response ) ) {
+			$this->logger->log( 'An unknown error occurred deleting the episode from Castos: ' . $api_response->get_error_message() );
+
+			return false;
+		}
+
+		$response_object = json_decode( wp_remote_retrieve_body( $api_response ) );
+
+		if ( ! isset( $response_object->success ) || ! $response_object->success ) {
+			$this->logger->log( 'An error occurred deleting the episode from Castos', $response_object );
+
+			return false;
+		}
+
 
 		return true;
 	}

--- a/php/classes/handlers/class-castos-handler.php
+++ b/php/classes/handlers/class-castos-handler.php
@@ -346,7 +346,7 @@ class Castos_Handler {
 
 		$this->logger->log( 'Upload Podcast Response', $response_object );
 
-		if ( ! isset( $response_object->status ) || ! $response_object->status ) {
+		if ( ! isset( $response_object->success ) || ! $response_object->success ) {
 			$this->logger->log( 'An error occurred uploading the episode data to Castos', $response_object );
 			$this->update_response( 'message', 'An error occurred uploading the episode data to Castos' );
 
@@ -376,7 +376,7 @@ class Castos_Handler {
 	/**
 	 * Delete a post from Castos when it's trashed in WordPress
 	 *
-	 * @param $post
+	 * @param \WP_Post $post
 	 *
 	 * @return bool
 	 */
@@ -409,6 +409,8 @@ class Castos_Handler {
 				'body'    => $post_body,
 			)
 		);
+
+		delete_post_meta( $post->ID, 'podmotor_episode_id' );
 
 		$this->logger->log( 'Delete Podcast api_response', $api_response );
 


### PR DESCRIPTION
I'm not sure about the restoring from trash part, cannot test it on my local site. The problem is that on my dev site, when I restore podcast from the trash, I get a 500 error from the API when trying to recreate the episode (`castos_handler::upload_podcast_to_podmotor`). Can we check why API returns a 500 error there?