### PR TITLE
Change the priority of redirect_old_feed hook so that it will run aft…

### DIFF
--- a/php/classes/controllers/class-feed-controller.php
+++ b/php/classes/controllers/class-feed-controller.php
@@ -39,7 +39,7 @@ class Feed_Controller extends Controller {
 		add_action( 'init', array( $this, 'add_feed' ), 11 );
 
 		// Handle v1.x feed URL as well as feed URLs for default permalinks.
-		add_action( 'init', array( $this, 'redirect_old_feed' ), 11 );
+		add_action( 'init', array( $this, 'redirect_old_feed' ), 12 );
 
 		// Sanitize the podcast image
 		add_filter( 'ssp_feed_image', array( $this, 'sanitize_image' ) );


### PR DESCRIPTION
…er register_post_type hook

Fixes #685. Another solution might be something that keeps both at priority 11 but ensures redirect_old_feed gets registered second. Bumping the redirect to priority 12 seems to work well on my site..