### PR TITLE
Use constant SSP_CPT_PODCAST instead of 'podcast' for post type for consistency

### DIFF
--- a/php/classes/controllers/class-extensions-controller.php
+++ b/php/classes/controllers/class-extensions-controller.php
@@ -121,7 +121,7 @@ class Extensions_Controller extends Controller {
 			$elementor_templates = array(
 				'title'       => __( 'Elementor Templates', 'seriously-simple-podcasting' ),
 				'image'       => $image_dir . 'elementor.jpg',
-				'url'         => wp_nonce_url( admin_url( 'edit.php?post_type=podcast&page=podcast_settings&tab=extensions&elementor_import_templates=true' ), '', 'import_template_nonce' ),
+				'url'         => wp_nonce_url( admin_url( 'edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_settings&tab=extensions&elementor_import_templates=true' ), '', 'import_template_nonce' ),
 				'description' => __( 'Looking for a custom elementor template to use with Seriously Simple Podcasting? Click here to import all of them righ now!', 'seriously-simple-podcasting' ),
 				'button_text' => __( 'Import Templates', 'seriously-simple-podcasting' ),
 				'new_window'  => 'redirect'

--- a/php/classes/controllers/class-options-controller.php
+++ b/php/classes/controllers/class-options-controller.php
@@ -348,7 +348,7 @@ class Options_Controller extends Controller {
 	 */
 	public function add_menu_item() {
 		add_submenu_page(
-			'edit.php?post_type=podcast',
+			'edit.php?post_type='. SSP_CPT_PODCAST,
 			__( 'Podcast Options', 'seriously-simple-podcasting' ),
 			__( 'Options', 'seriously-simple-podcasting' ),
 			'manage_podcast',

--- a/php/classes/controllers/class-settings-controller.php
+++ b/php/classes/controllers/class-settings-controller.php
@@ -152,12 +152,12 @@ class Settings_Controller extends Controller {
 	 * @return void
 	 */
 	public function add_menu_item() {
-		add_submenu_page( 'edit.php?post_type=podcast', __( 'Podcast Settings', 'seriously-simple-podcasting' ), __( 'Settings', 'seriously-simple-podcasting' ), 'manage_podcast', 'podcast_settings', array(
+		add_submenu_page( 'edit.php?post_type='. SSP_CPT_PODCAST, __( 'Podcast Settings', 'seriously-simple-podcasting' ), __( 'Settings', 'seriously-simple-podcasting' ), 'manage_podcast', 'podcast_settings', array(
 			$this,
 			'settings_page',
 		) );
 
-		add_submenu_page( 'edit.php?post_type=podcast', __( 'Extensions', 'seriously-simple-podcasting' ), __( 'Extensions', 'seriously-simple-podcasting' ), 'manage_podcast', 'podcast_settings&tab=extensions', array(
+		add_submenu_page( 'edit.php?post_type='. SSP_CPT_PODCAST, __( 'Extensions', 'seriously-simple-podcasting' ), __( 'Extensions', 'seriously-simple-podcasting' ), 'manage_podcast', 'podcast_settings&tab=extensions', array(
 			$this,
 			'settings_page',
 		) );
@@ -177,7 +177,7 @@ class Settings_Controller extends Controller {
 	 * @return array $links Modified links
 	 */
 	public function add_plugin_links( $links ) {
-		$settings_link = '<a href="edit.php?post_type=podcast&page=podcast_settings">' . __( 'Settings', 'seriously-simple-podcasting' ) . '</a>';
+		$settings_link = '<a href="edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_settings">' . __( 'Settings', 'seriously-simple-podcasting' ) . '</a>';
 		array_push( $links, $settings_link );
 
 		return $links;

--- a/php/classes/handlers/class-admin-notifications-handler.php
+++ b/php/classes/handlers/class-admin-notifications-handler.php
@@ -265,7 +265,7 @@ class Admin_Notifications_Handler {
 		$revalidate_api_credentials_url  = wp_nonce_url(
 			add_query_arg(
 				array( 'ssp_revalidate_api_credentials' => 'true' ),
-				admin_url( 'edit.php?post_type=podcast' )
+				admin_url( 'edit.php?post_type='. SSP_CPT_PODCAST )
 			),
 			'revalidate-api-credentials'
 		);
@@ -583,7 +583,7 @@ class Admin_Notifications_Handler {
 					),
 				)
 			),
-			esc_url( admin_url( 'edit.php?post_type=podcast&page=podcast_options' ) )
+			esc_url( admin_url( 'edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_options' ) )
 		);
 		?>
 		<div class="notice notice-info">
@@ -596,7 +596,7 @@ class Admin_Notifications_Handler {
 	 * Show the Distrubution Links Upgrade notice, prompting the user to trigger the upgrade, as well as download a copy of their current settings
 	 */
 	public function show_distribution_links_upgrade_notice() {
-		$distribution_backup_url = add_query_arg( '_wpnonce', wp_create_nonce( 'export_options' ), admin_url( 'edit.php?post_type=podcast&page=podcast_options&export_options=true' ) );
+		$distribution_backup_url = add_query_arg( '_wpnonce', wp_create_nonce( 'export_options' ), admin_url( 'edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_options&export_options=true' ) );
 		$distribution_backup = sprintf(
 			wp_kses(
 				// translators: Placeholder is the url to download the current options
@@ -610,7 +610,7 @@ class Admin_Notifications_Handler {
 			),
 			$distribution_backup_url //esc_url( admin_url( 'edit.php?post_type=podcast&page=podcast_options&export_options=true' ) )
 		);
-		$distribution_upgrade_url = add_query_arg( '_wpnonce', wp_create_nonce( 'upgrade_options' ), admin_url( 'edit.php?post_type=podcast&page=podcast_options&upgrade_options=true' ) );
+		$distribution_upgrade_url = add_query_arg( '_wpnonce', wp_create_nonce( 'upgrade_options' ), admin_url( 'edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_options&upgrade_options=true' ) );
 		$distribution_upgrade = sprintf(
 			wp_kses(
 				// translators: Placeholders are the url to run the upgrade, and the url to the relevant help document
@@ -665,7 +665,7 @@ class Admin_Notifications_Handler {
 					),
 				)
 			),
-			esc_url( admin_url('edit.php?post_type=podcast&page=podcast_settings&tab=extensions') )
+			esc_url( admin_url('edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_settings&tab=extensions') )
 		);
 
 		$ignore_message_url = add_query_arg( array( 'ssp_disable_elementor_template_notice' => 'true' ) );

--- a/templates/onboarding/step-5.php
+++ b/templates/onboarding/step-5.php
@@ -30,7 +30,7 @@
 			<div class="ssp-onboarding__links-item">
 				<h2>Creating your first episode</h2>
 				<p>Get started by creating your first episode with Seriously Simple Podcasting.</p>
-				<a href="<?php echo admin_url('post-new.php?post_type=podcast') ?>" class="button"><span>Let’s Start</span></a>
+				<a href="<?php echo admin_url('post-new.php?post_type='. SSP_CPT_PODCAST) ?>" class="button"><span>Let’s Start</span></a>
 			</div>
 		</div>
 	</div>

--- a/templates/onboarding/steps-footer.php
+++ b/templates/onboarding/steps-footer.php
@@ -1,3 +1,3 @@
 <div class="ssp-onboarding__skip">
-	<a href="<?php echo admin_url('edit.php?post_type=podcast&page=podcast_settings') ?>">Skip Setup</a>
+	<a href="<?php echo admin_url('edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_settings') ?>">Skip Setup</a>
 </div>

--- a/tests/acceptance/ValidateApiKeyCest.php
+++ b/tests/acceptance/ValidateApiKeyCest.php
@@ -13,7 +13,7 @@ class ValidateApiKeyCest
 		$apiKey = '2y10U8GdHpFsIndddWDB52cO8r859w4PVzoha0iNXY2eiQqosvkOap6';
 
     	$I->loginAsAdmin();
-    	$I->amOnPage('wp-admin/edit.php?post_type=podcast&page=podcast_settings&tab=castos-hosting');
+    	$I->amOnPage('wp-admin/edit.php?post_type='. SSP_CPT_PODCAST .'&page=podcast_settings&tab=castos-hosting');
     	$I->see('Connect your WordPress site to your Castos account');
     	$I->fillField('#podmotor_account_email', $email);
     	$I->fillField('#podmotor_account_api_token', $apiKey);


### PR DESCRIPTION
This allows to override the SSP_CPT_PODCAST and use an alternate name for the post_type instead of using **podcast**.