### PR TITLE
Improve schema output

### DIFF
--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -1511,7 +1511,7 @@ class Frontend_Controller extends Controller {
 						if ( get_option( 'permalink_structure' ) ) {
 							$file = $this->get_episode_download_link( $episode_id );
 						}
-						$html .= '<div class="podcast_player">' . $this->media_player( $file, $episode_id, "large" ) . '</div>' . "\n";
+						$html .= '<div id="podcast_player_' . $episode_id . '" class="podcast_player">' . $this->media_player( $file, $episode_id, "large" ) . '</div>' . "\n";
 						break;
 
 					case 'details':

--- a/php/classes/controllers/class-schema-controller.php
+++ b/php/classes/controllers/class-schema-controller.php
@@ -50,7 +50,7 @@ class Schema_Controller extends Controller {
 			$data['mainEntityOfPage'] = $context->canonical . '#/schema/podcast';
 			$data['potentialAction']  = array(
 				"@type"  => "ListenAction",
-				"target" => $context->canonical . 'podcast_player_' . get_the_ID(),
+				"target" => $context->canonical . '#podcast_player_' . get_the_ID(),
 				"object" => array( "@id" => $context->canonical . '#/schema/podcast' ),
 			);
 		}

--- a/php/classes/controllers/class-schema-controller.php
+++ b/php/classes/controllers/class-schema-controller.php
@@ -3,9 +3,9 @@
 namespace SeriouslySimplePodcasting\Controllers;
 
 
-
 use SeriouslySimplePodcasting\Integrations\Yoast\Schema\PodcastEpisode;
 use SeriouslySimplePodcasting\Integrations\Yoast\Schema\PodcastSeries;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -25,14 +25,35 @@ class Schema_Controller extends Controller {
 		parent::__construct( $file, $version );
 
 		add_filter( 'wpseo_schema_graph_pieces', array( $this, 'add_graph_pieces' ) );
+		add_filter( 'wpseo_schema_webpage', array( $this, 'filter_webpage' ) );
 	}
 
-    public static function add_graph_pieces( $data ) {
-		return $data; //todo: remove this line
-
+	public static function add_graph_pieces( $data ) {
 		$data[] = new PodcastEpisode();
 		$data[] = new PodcastSeries();
 
-        return $data;
-    }
+		return $data;
+	}
+
+	/**
+	 * Changes the Yoast webpage output.
+	 *
+	 * @param array             $data    The Schema Organization data.
+	 * @param Meta_Tags_Context $context Context value object.
+	 *
+	 * @return array $data The Schema Organization data.
+	 */
+	public function filter_webpage( $data, $context ) {
+		$ssp_post_types = ssp_post_types( true );
+
+		if ( is_singular( $ssp_post_types ) ) {
+			$data['mainEntityOfPage'] = $context->canonical . '#/schema/podcast';
+			$data['potentialAction']  = array(
+				"@type"  => "ListenAction",
+				"target" => $context->canonical . '#/schema/podcast',
+			);
+		}
+
+		return $data;
+	}
 }

--- a/php/classes/controllers/class-schema-controller.php
+++ b/php/classes/controllers/class-schema-controller.php
@@ -50,7 +50,8 @@ class Schema_Controller extends Controller {
 			$data['mainEntityOfPage'] = $context->canonical . '#/schema/podcast';
 			$data['potentialAction']  = array(
 				"@type"  => "ListenAction",
-				"target" => $context->canonical . '#/schema/podcast',
+				"target" => $context->canonical . 'podcast_player_' . get_the_ID(),
+				"object" => array( "@id" => $context->canonical . '#/schema/podcast' ),
 			);
 		}
 

--- a/php/classes/integrations/yoast/schema/class-podcast-episode.php
+++ b/php/classes/integrations/yoast/schema/class-podcast-episode.php
@@ -57,17 +57,17 @@ class PodcastEpisode extends Abstract_Schema_Piece {
 		$duration    = $this->get_duration( $this->context->post->ID, $ss_podcasting, $enclosure );
 
 		$schema = array(
-			"@type"         => [ "PodcastEpisode", "OnDemandEvent" ],
-			"@id"           => $this->context->canonical . '#/schema/podcast',
+			"@type"               => [ "PodcastEpisode", "OnDemandEvent" ],
+			"@id"                 => $this->context->canonical . '#/schema/podcast',
 			"eventAttendanceMode" => "https://schema.org/OnlineEventAttendanceMode",
-			"location" => array(
+			"location"            => array(
 				"@type" => "VirtualLocation",
 				"url"   => $this->context->canonical,
 				"@id"   => $this->context->canonical . "#webpage",
 			),
-			"url"           => $this->context->canonical,
-			"name"          => $this->context->title,
-			"datePublished" => date( 'Y-m-d', strtotime( $this->context->post->post_date ) ),
+			"url"                 => $this->context->canonical,
+			"name"                => $this->context->title,
+			"datePublished"       => date( 'Y-m-d', strtotime( $this->context->post->post_date ) ),
 		);
 
 		if ( $description ) {

--- a/php/classes/integrations/yoast/schema/class-podcast-episode.php
+++ b/php/classes/integrations/yoast/schema/class-podcast-episode.php
@@ -7,6 +7,7 @@
 
 namespace SeriouslySimplePodcasting\Integrations\Yoast\Schema;
 
+use SeriouslySimplePodcasting\Controllers\Frontend_Controller;
 use Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece;
 
 /**
@@ -28,9 +29,9 @@ class PodcastEpisode extends Abstract_Schema_Piece {
 	}
 
 	/**
-	 * Returns the Organization Schema data.
+	 * Returns the Podcast Schema data.
 	 *
-	 * @return array $data The Organization schema.
+	 * @return array $data The schema data.
 	 */
 	public function generate() {
 		global $ss_podcasting;
@@ -40,19 +41,30 @@ class PodcastEpisode extends Abstract_Schema_Piece {
 
 		foreach ( $series as $term ) {
 			/** @var \WP_Term $term */
+
+			$url = get_term_link( $term );
+
 			$series_parts[] = array(
 				"@type" => "PodcastSeries",
 				"name"  => $term->name,
-				"url"   => get_term_link( $term ),
+				"url"   => $url,
+				"id"    => $url . '#/schema/podcastSeries',
 			);
 		}
 
-		$enclosure     = $ss_podcasting->get_enclosure( $this->context->post->ID );
-		$description   = get_the_excerpt( $this->context->post->ID );
-		$time_required = $this->generate_required_time( $this->context->post->ID );
+		$enclosure   = $ss_podcasting->get_enclosure( $this->context->post->ID );
+		$description = get_the_excerpt( $this->context->post->ID );
+		$duration    = $this->get_duration( $this->context->post->ID, $ss_podcasting, $enclosure );
 
 		$schema = array(
-			"@type"         => "PodcastEpisode",
+			"@type"         => [ "PodcastEpisode", "OnDemandEvent" ],
+			"@id"           => $this->context->canonical . '#/schema/podcast',
+			"eventAttendanceMode" => "https://schema.org/OnlineEventAttendanceMode",
+			"location" => array(
+				"@type" => "VirtualLocation",
+				"url"   => $this->context->canonical,
+				"@id"   => $this->context->canonical . "#webpage",
+			),
 			"url"           => $this->context->canonical,
 			"name"          => $this->context->title,
 			"datePublished" => date( 'Y-m-d', strtotime( $this->context->post->post_date ) ),
@@ -62,15 +74,12 @@ class PodcastEpisode extends Abstract_Schema_Piece {
 			$schema['description'] = $description;
 		}
 
-		if ( $time_required ) {
-			$schema['timeRequired'] = $time_required;
+		if ( ! empty( $duration ) ) {
+			$schema['duration'] = $duration;
 		}
 
 		if ( $enclosure ) {
-			$schema['associatedMedia'] = array(
-				"@type"      => "MediaObject",
-				"contentUrl" => $ss_podcasting->get_enclosure( $this->context->post->ID ),
-			);
+			$schema = $this->add_enclosure_to_schema( $ss_podcasting, $enclosure, $schema );
 		}
 
 		if ( $series_parts ) {
@@ -80,13 +89,28 @@ class PodcastEpisode extends Abstract_Schema_Piece {
 		return $schema;
 	}
 
-	protected function generate_required_time( $episode_id ) {
+	/**
+	 * Gets a ISO 8601 duration compliant duration string.
+	 *
+	 * @param int                 $episode_id
+	 * @param Frontend_Controller $ss_podcasting
+	 * @param string              $enclosure
+	 *
+	 * @return string
+	 */
+	protected function get_duration( $episode_id, $ss_podcasting, $enclosure ) {
 		$duration = get_post_meta( $episode_id, 'duration', true );
+		if ( empty( $duration ) ) {
+			$duration = $ss_podcasting->get_file_duration( $enclosure );
+			if ( $duration ) {
+				update_post_meta( $episode_id, 'duration', $duration );
+			}
+		}
 
 		preg_match( '/(\d\d:\d\d:\d\d)/', $duration, $matches );
 
 		if ( empty( $matches ) ) {
-			return null;
+			return '';
 		}
 
 		$time_parts = explode( ':', $duration );
@@ -109,5 +133,42 @@ class PodcastEpisode extends Abstract_Schema_Piece {
 		}
 
 		return $time;
+	}
+
+	/**
+	 * Add the enclosure to the schema based on its type.
+	 *
+	 * @param Frontend_Controller $ss_podcasting
+	 * @param string              $enclosure
+	 * @param array               $schema
+	 *
+	 * @return array
+	 */
+	private function add_enclosure_to_schema( $ss_podcasting, $enclosure, $schema ) {
+		$type = $ss_podcasting->get_episode_type();
+
+		$object = array(
+			"contentUrl"  => $enclosure,
+			"contentSize" => $ss_podcasting->get_file_size(),
+		);
+
+		if ( $type === 'audio' ) {
+			$object['@type'] = "AudioObject";
+			$schema['audio'] = $object;
+
+			return $schema;
+		}
+
+		if ( $type === 'video' ) {
+			$object['@type'] = "VideoObject";
+			$schema['video'] = $object;
+
+			return $schema;
+		}
+
+		$object['@type']           = "MediaObject";
+		$schema['associatedMedia'] = $object;
+
+		return $schema;
 	}
 }

--- a/php/classes/integrations/yoast/schema/class-podcast-series.php
+++ b/php/classes/integrations/yoast/schema/class-podcast-series.php
@@ -44,6 +44,7 @@ class PodcastSeries extends Abstract_Schema_Piece {
 
 		$schema = array(
 			"@type"   => "PodcastSeries",
+			"@id"     => $this->context->canonical . '#/schema/podcastSeries',
 			"image"   => $ssp_admin->get_series_image_src( $series ),
 			"url"     => $this->context->canonical,
 			"name"    => $this->context->title,


### PR DESCRIPTION
This pull intends to:

* Improve the Schema output for `PodcastEpisode` by:
  * Adding an `@id`.
  * Double typing it to an `OnDemandEvent` as well.
  * Adding `eventAttendanceMode`.
  * Adding a `location` attribute.
  * Making the `mediaObject` output more specific for either `audio` or `video` types.
  * Making sure `duration` is added.

* Improve the Schema output for `PodcastSeries`:
  * Adding an `@id`.

* Filter the `webpage` Schema to add (on podcast pages):
  * A `ListenAction`, pointing to the podcast by `id` attribute on the page and by `object` to the Schema object.
  * Setting the podcast as the `mainEntity`.

⚠️ I removed the early return in `add_graph_pieces`, not sure if you're happy with that. ⚠️ 