### PR TITLE
Applied solution for not validated RSS by W3 Validator

### DIFF
--- a/php/classes/controllers/class-feed-controller.php
+++ b/php/classes/controllers/class-feed-controller.php
@@ -316,10 +316,10 @@ class Feed_Controller extends Controller {
 		}
 		$explicit_option = apply_filters( 'ssp_feed_explicit', $explicit_option, $series_id );
 		if ( $explicit_option && 'on' === $explicit_option ) {
-			$itunes_explicit     = 'yes';
+			$itunes_explicit     = 'true';
 			$googleplay_explicit = 'Yes';
 		} else {
-			$itunes_explicit     = 'clean';
+			$itunes_explicit     = 'false';
 			$googleplay_explicit = 'No';
 		}
 

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -58,7 +58,7 @@ if ( $stylesheet_url ) {
 	<channel>
 		<title><?php echo esc_html( $title ); ?></title>
 		<atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml"/>
-		<link><?php echo esc_url( apply_filters( 'ssp_feed_channel_link_tag', $ss_podcasting->home_url, $podcast_series ) ) ?></link>
+		<link><?php echo $feed_link ?></link>
 		<description><?php echo esc_html( $description ); ?></description>
 		<lastBuildDate><?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', get_lastpostmodified( 'GMT' ), false ) ); ?></lastBuildDate>
 		<language><?php echo esc_html( $language ); ?></language>
@@ -86,7 +86,7 @@ if ( $stylesheet_url ) {
 			<image>
 				<url><?php echo esc_url( $image ); ?></url>
 				<title><?php echo esc_html( $title ); ?></title>
-				<link><?php echo esc_url( apply_filters( 'ssp_feed_channel_link_tag', $ss_podcasting->home_url, $podcast_series ) ) ?></link>
+				<link><?php echo $feed_link ?></link>
 			</image>
 		<?php }
 		if ( isset( $category1['category'] ) && $category1['category'] ) { ?>

--- a/templates/feed/feed-item.php
+++ b/templates/feed/feed-item.php
@@ -209,7 +209,7 @@ $title = esc_html( get_the_title_rss() );
 	<pubDate><?php echo $pub_date; ?></pubDate>
 	<dc:creator><![CDATA[<?php echo $author; ?>]]></dc:creator>
 	<guid isPermaLink="false"><?php the_guid(); ?></guid>
-	<description><![CDATA[<?php echo $description; ?>]]></description>
+	<description><![CDATA[ <?php echo '<img src="' . esc_url( $episode_image ) . '" />'; ?> <?php echo $description; ?>]]></description>
 	<itunes:subtitle><![CDATA[<?php echo $itunes_subtitle; ?>]]></itunes:subtitle>
 	<?php if ( $keywords ) : ?>
 		<itunes:keywords><?php echo $keywords; ?></itunes:keywords>
@@ -236,10 +236,6 @@ $title = esc_html( get_the_title_rss() );
 	<?php } ?>
 	<?php if ( $episode_image ) { ?>
 		<itunes:image href="<?php echo esc_url( $episode_image ); ?>"></itunes:image>
-		<image>
-			<url><?php echo esc_url( $episode_image ); ?></url>
-			<title><?php echo esc_attr( $title ); ?></title>
-		</image>
 	<?php } ?>
 	<itunes:explicit><?php echo esc_html( $itunes_explicit_flag ); ?></itunes:explicit>
 	<itunes:block><?php echo esc_html( $block_flag ); ?></itunes:block>


### PR DESCRIPTION
In the version 2.23.0 and previous, W3 Validator doesn't validate the RSS. Often Google Podcasts is removing the podcasts served by that not validated RS. Here the solution applied:
https://stackoverflow.com/questions/77242573/solution-for-wordpress-castos-plugin-seriously-simple-podcasting-ssp-rss-vali