### PR TITLE
Version 3.5.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -92,14 +92,14 @@ jobs:
 
       - name: Upload codeception output on failure
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: acceptance-tests
           path: wp-content/plugins/seriously-simple-podcasting/tests/_output
 
       - name: Upload PHP server logs on failure
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: acceptance-tests
           path: nohup.out

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seriously-simple-podcasting",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "main": "build/index.js",
   "author": "CastosHQ",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: podcast, audio, itunes, podcasting, playlist
 Requires at least: 5.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 3.4.1
+Stable tag: 3.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -164,6 +164,19 @@ You can find complete user and developer documentation (along with the FAQs) on 
 15. View podcast episodes in the At A Glance widget on the main WordPress dashboard.
 
 == Changelog ==
+
+= 3.5.0 =
+2024-09-11
+[UPDATE] Enhanced UX/UI for Hosting (Castos connection) settings
+[UPDATE] Display success and error messages for Castos connection
+[UPDATE] Auto-disconnect SSP when users are disconnected on Castos
+[UPDATE] Display Castos sync status after saving episodes
+[UPDATE] Added filter for allowed tags in the feed description
+[UPDATE] Removed the "1,000 Subscriber Challenge" from the settings sidebar
+[FIX] Handle PHP exceptions in the ssp_readfile_chunked() function
+[FIX] Catch potential PHP errors during episode file downloads
+[FIX] Support additional classes in the player and podcast playlist blocks
+[FIX] Use dark mode for the playlist block when dark mode is set in the settings
 
 = 3.4.1 =
 2024-07-31

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.5.0-alpha.8
+ * Version: 3.5.0
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.5.0-alpha.8' );
+define( 'SSP_VERSION', '3.5.0' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/src/components/EpisodeSyncStatus.js
+++ b/src/components/EpisodeSyncStatus.js
@@ -26,6 +26,9 @@ const EpisodeSyncStatus = () => {
 
 			if (updatedPost && updatedPost[ 'episode_data' ]) {
 				let syncStatus = updatedPost[ 'episode_data' ].syncStatus
+				if ( 'none' === syncStatus.status ) {
+					return; // Do not show redundant "Not Synced yet" status.
+				}
 				displayNotice(syncStatus)
 				updateSyncStatus(syncStatus)
 			}


### PR DESCRIPTION
= 3.5.0 =
2024-09-11
[UPDATE] Enhanced UX/UI for Hosting (Castos connection) settings
[UPDATE] Display success and error messages for Castos connection
[UPDATE] Auto-disconnect SSP when users are disconnected on Castos
[UPDATE] Display Castos sync status after saving episodes
[UPDATE] Added filter for allowed tags in the feed description
[UPDATE] Removed the "1,000 Subscriber Challenge" from the settings sidebar
[FIX] Handle PHP exceptions in the ssp_readfile_chunked() function
[FIX] Catch potential PHP errors during episode file downloads
[FIX] Support additional classes in the player and podcast playlist blocks
[FIX] Use dark mode for the playlist block when dark mode is set in the settings