### PR TITLE
Version 3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seriously-simple-podcasting",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": "build/index.js",
   "author": "CastosHQ",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: podcast, audio, itunes, podcasting, playlist
 Requires at least: 5.3
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 3.7.0
+Stable tag: 3.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -164,6 +164,18 @@ You can find complete user and developer documentation (along with the FAQs) on 
 15. View podcast episodes in the At A Glance widget on the main WordPress dashboard.
 
 == Changelog ==
+
+= 3.7.1 =
+2024-12-12
+[UPDATE] Improved plugin performance ( lazy loading for settings, caching ).
+[UPDATE] Enhanced SSP feed data filters.
+[FIX] Fixed an issue with attempting to sync memberships with Castos when not connected.
+
+#### Developer Updates
+* Added the $series_id parameter to the following feed filters: `ssp_feed_data`, `ssp_feed_no_access_message`, `ssp_private_feed_message`, `ssp_feed_no_access_path`, `ssp_feed_number_of_posts`, `ssp_feed_channel_link_tag`.
+* Added the $podcast_series parameter to the `ssp_feed_number_of_posts` filter.
+* Added the $podcast_id parameter to the `ssp_feed_channel_link_tag` filter.
+* Added the $post_id and $is_excerpt_mode parameters to the `the_excerpt_rss` filter.
 
 = 3.7.0 =
 2024-11-25

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.7.1-alpha.2
+ * Version: 3.7.1
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.7.1-alpha.2' );
+define( 'SSP_VERSION', '3.7.1' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
= 3.7.1 =
2024-12-12
[UPDATE] Improved plugin performance ( lazy loading for settings, caching ).
[UPDATE] Enhanced SSP feed data filters.
[FIX] Fixed an issue with attempting to sync memberships with Castos when not connected.

#### Developer Updates
* Added the $series_id parameter to the following feed filters: `ssp_feed_data`, `ssp_feed_no_access_message`, `ssp_private_feed_message`, `ssp_feed_no_access_path`, `ssp_feed_number_of_posts`, `ssp_feed_channel_link_tag`.
* Added the $podcast_series parameter to the `ssp_feed_number_of_posts` filter.
* Added the $podcast_id parameter to the `ssp_feed_channel_link_tag` filter.
* Added the $post_id and $is_excerpt_mode parameters to the `the_excerpt_rss` filte