### PR TITLE
Tag filter for playlist player

### DIFF
--- a/php/classes/integrations/blocks/class-castos-blocks.php
+++ b/php/classes/integrations/blocks/class-castos-blocks.php
@@ -417,6 +417,14 @@ class Castos_Blocks {
 						'type'    => 'string',
 						'default' => '-1',
 					),
+					'availableTags'   => array(
+						'type'    => 'array',
+						'default' => $this->get_tags(),
+					),
+					'selectedTag'     => array(
+						'type'    => 'string',
+						'default' => '',
+					),
 					// Use string everywhere instead of number because of the WP bug.
 					// It doesn't show the saved value in the admin after page refresh.
 					'limit'        => array(
@@ -438,6 +446,10 @@ class Castos_Blocks {
 
 					if ( $podcast_id ) {
 						$args['series'] = $this->get_term_slug_by_id( $podcast_id );
+					}
+
+					if ( ! empty( $attributes['selectedTag'] ) ) {
+						$args['tag'] = $attributes['selectedTag'];
 					}
 
 					if ( ! empty( $attributes['limit'] ) ) {
@@ -500,5 +512,24 @@ class Castos_Blocks {
 					'value' => $item->term_id,
 				);
 			}, ssp_get_podcasts() ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function get_tags() {
+		return array_merge(
+			array(
+				array(
+					'label' => __( '-- All --', 'seriously-simple-podcasting' ),
+					'value' => '',
+				),
+			),
+			array_map( function ( $item ) {
+				return array(
+					'label' => $item->name,
+					'value' => $item->slug,
+				);
+			}, ssp_get_tags() ) );
 	}
 }

--- a/php/classes/repositories/class-episode-repository.php
+++ b/php/classes/repositories/class-episode-repository.php
@@ -256,6 +256,11 @@ class Episode_Repository implements Service {
 			}
 		}
 
+		// Limit query to only episodes with specified tag(s)
+		if ( $atts['tag'] ) {
+			$query_args['tag'] = $atts['tag'];
+		}
+
 		// Allow dynamic filtering of query args
 		$query_args = apply_filters( 'ssp_podcast_playlist_query_args', $query_args );
 

--- a/php/classes/shortcodes/class-podcast-playlist.php
+++ b/php/classes/shortcodes/class-podcast-playlist.php
@@ -107,6 +107,7 @@ class Podcast_Playlist implements Shortcode {
 			array(
 				'type'         => 'audio',
 				'series'       => '',
+				'tag'          => '',
 				'order'        => 'ASC',
 				'orderby'      => 'menu_order ID',
 				'include'      => '',

--- a/php/includes/ssp-functions.php
+++ b/php/includes/ssp-functions.php
@@ -1727,6 +1727,26 @@ if ( ! function_exists( 'ssp_get_podcasts' ) ) {
 }
 
 /**
+ * Gets array of tags.
+ */
+if ( ! function_exists( 'ssp_get_tags' ) ) {
+	/**
+	 * Gets array of tags.
+	 *
+	 * @param bool $hide_empty
+	 *
+	 * @return WP_Term[]
+	 */
+	function ssp_get_tags( $hide_empty = false ) {
+		$tags = get_terms( 'post_tag', array(
+			'post_type' => ssp_post_types(),
+			'hide_empty' => $hide_empty,
+		) );
+		return is_array( $tags ) ? $tags : array();
+	}
+}
+
+/**
  * Gets SSP Version.
  */
 if ( ! function_exists( 'ssp_version' ) ) {

--- a/src/components/EditPlaylistPlayer.js
+++ b/src/components/EditPlaylistPlayer.js
@@ -20,6 +20,8 @@ class EditPlaylistPlayer extends Component {
 
 		const {
 			availablePodcasts,
+			availableTags,
+			selectedTag,
 			limit,
 			orderBy,
 			order,
@@ -41,6 +43,21 @@ class EditPlaylistPlayer extends Component {
 								onChange={(selectedPodcast) => {
 									setAttributes({
 										selectedPodcast: selectedPodcast
+									});
+								}}
+							/>
+						</PanelRow>
+						<PanelRow>
+							<label htmlFor="ssp-playlist-player-tag">
+								{__('Select Tag', 'seriously-simple-podcasting')}
+							</label>
+							<SelectControl
+								id="ssp-playlist-player-tag"
+								value={selectedTag}
+								options={availableTags}
+								onChange={(selectedTag) => {
+									setAttributes({
+										selectedTag: selectedTag
 									});
 								}}
 							/>


### PR DESCRIPTION
Use case: Add a playlist player block to a page which will play the 5 most recent podcast episodes that have a specific tag.