### PR TITLE
Version 3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seriously-simple-podcasting",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "main": "build/index.js",
   "author": "CastosHQ",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: podcast, audio, itunes, podcasting, playlist
 Requires at least: 5.3
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 3.9.0
+Stable tag: 3.10.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -164,6 +164,17 @@ You can find complete user and developer documentation (along with the FAQs) on 
 15. View podcast episodes in the At A Glance widget on the main WordPress dashboard.
 
 == Changelog ==
+
+= 3.10.0 =
+2025-04-14
+[UPDATE] Added a listener to update Castos subscriptions when a WooCommerce Memberships customer changes their email.
+[UPDATE] Added a setting to limit the maximum number of episodes in the feed.
+[UPDATE] Improved support for cloning custom post types using duplicator plugins.
+[UPDATE] Added the ability to modify the series taxonomy programmatically.
+[FIX] Prevented redundant sync errors when saving episodes without a file.
+[FIX] Fixed jsonSerialize() return type error.
+[FIX] Fixed podcast categories not displaying correctly in the WordPress API.
+[FIX] Security improvements.
 
 = 3.9.0 =
 2025-02-27

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.10.0-alpha.8
+ * Version: 3.10.0
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.10.0-alpha.8' );
+define( 'SSP_VERSION', '3.10.0' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
= 3.10.0 =
2025-04-14
[UPDATE] Added a listener to update Castos subscriptions when a WooCommerce Memberships customer changes their email.
[UPDATE] Added a setting to limit the maximum number of episodes in the feed.
[UPDATE] Improved support for cloning custom post types using duplicator plugins.
[UPDATE] Added the ability to modify the series taxonomy programmatically.
[FIX] Prevented redundant sync errors when saving episodes without a file.
[FIX] Fixed jsonSerialize() return type error.
[FIX] Fixed podcast categories not displaying correctly in the WordPress API.
[FIX] Security improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a listener to update Castos subscriptions when a customer's email changes.
  - Added a setting to limit the maximum number of episodes in the feed.
  - Enhanced support for cloning custom post types and enabled programmatic modification of series taxonomy.

- **Bug Fixes**
  - Fixed issues causing redundant sync errors, incorrect JSON responses, and podcast category display problems via the API.

- **Security**
  - Implemented several security improvements.

- **Update**
  - Upgraded the plugin to version 3.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->