### PR TITLE
Release/3.13.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -37,14 +37,13 @@
 				<element key="0" value="seriously-simple-podcasting"/>
 				<element key="1" value="SSP"/>
 				<element key="2" value="SeriouslySimplePodcasting"/>
+				<element key="3" value="ssp"/>
 			</property>
 		</properties>
 		<!-- Exclude constants as SSP prefix is legacy and widely used -->
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.ShortPrefixPassed"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.InvalidPrefixPassed"/>
-		<!-- Allow custom hook naming convention with slashes -->
-		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound"/>
 	</rule>
 	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<!-- Allow custom hook naming convention with slashes for better organization -->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,7 +8,6 @@
 	<exclude-pattern>/tests/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/build/</exclude-pattern>
-	<exclude-pattern>/templates/</exclude-pattern>
 
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
@@ -44,6 +43,12 @@
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.ShortPrefixPassed"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.InvalidPrefixPassed"/>
+		<!-- Allow custom hook naming convention with slashes -->
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound"/>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidHookName">
+		<!-- Allow custom hook naming convention with slashes for better organization -->
+		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores"/>
 	</rule>
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/assets/css/podcast-list.css
+++ b/assets/css/podcast-list.css
@@ -1,0 +1,279 @@
+/**
+ * Podcast List Styles
+ * 
+ * Custom styles for the [ssp_podcasts] shortcode
+ * Extracted from podcast-list.php template
+ * 
+ * @package SeriouslySimplePodcasting
+ * @since 3.13.0
+ */
+
+.ssp-podcasts {
+	display: grid;
+	gap: 20px;
+	max-width: 100%;
+}
+
+/* Single column layout (default) */
+.ssp-podcasts-columns-1 {
+	grid-template-columns: 1fr;
+}
+
+/* Two column layout */
+.ssp-podcasts-columns-2 {
+	grid-template-columns: repeat(2, 1fr);
+}
+
+/* Three column layout */
+.ssp-podcasts-columns-3 {
+	grid-template-columns: repeat(3, 1fr);
+}
+
+.ssp-podcast-card {
+	display: flex;
+	background: #f8f9fa;
+	border-radius: 8px;
+	padding: 16px;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	transition: box-shadow 0.3s ease;
+	position: relative;
+}
+
+.ssp-podcast-card:hover {
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.ssp-podcast-image {
+	flex-shrink: 0;
+	width: 120px;
+	height: 120px;
+	margin-right: 20px;
+	border-radius: 8px;
+	overflow: hidden;
+	background: #e9ecef;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.ssp-podcast-image img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.ssp-podcast-placeholder {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: linear-gradient(135deg, #6c5ce7, #a29bfe);
+	color: white;
+	text-align: center;
+	padding: 10px;
+}
+
+.ssp-podcast-placeholder-text {
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.2;
+	word-break: break-word;
+}
+
+.ssp-podcast-content {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+}
+
+.ssp-podcast-header {
+	margin-bottom: 8px;
+}
+
+.ssp-podcast-title {
+	margin: 0;
+	font-size: 24px;
+	font-weight: 700;
+	color: #6c5ce7;
+	line-height: 1.2;
+}
+
+.ssp-listen-now-button {
+	background: #343a40;
+	color: white;
+	text-decoration: none;
+	padding: 8px 16px;
+	border-radius: 4px;
+	font-size: 14px;
+	font-weight: 600;
+	white-space: nowrap;
+	transition: background-color 0.3s ease;
+	display: inline-block;
+	margin-top: auto;
+	margin-left: auto;
+	width: fit-content;
+	box-sizing: border-box;
+}
+
+.ssp-listen-now-button:hover,
+.ssp-listen-now-button:focus {
+	background: #495057;
+	color: white;
+	text-decoration: none;
+	outline: 2px solid #6c5ce7;
+	outline-offset: 2px;
+}
+
+.ssp-listen-now-button:focus-visible {
+	outline: 2px solid #6c5ce7;
+	outline-offset: 2px;
+}
+
+.ssp-podcast-episode-count {
+	font-size: 16px;
+	color: #6c757d;
+	margin-bottom: 8px;
+	font-weight: 500;
+}
+
+.ssp-podcast-description {
+	font-size: 16px;
+	color: #6c757d;
+	line-height: 1.5;
+	margin: 0 0 16px 0;
+	text-align: justify;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+	/* Force single column layout on mobile for all column configurations */
+	.ssp-podcasts-columns-2,
+	.ssp-podcasts-columns-3 {
+		grid-template-columns: 1fr;
+	}
+	
+	.ssp-podcast-card {
+		flex-direction: column;
+		text-align: center;
+	}
+	
+	.ssp-podcast-image {
+		width: 300px;
+		height: 300px;
+		max-width: 90%;
+		max-height: 90%;
+		margin: 0 auto 15px auto;
+	}
+	
+	.ssp-podcast-title {
+		font-size: 20px;
+		text-align: center;
+	}
+	
+	.ssp-listen-now-button {
+		font-size: 12px;
+		padding: 12px 12px;
+		max-width: 300px;
+		width: 90%;
+		display: block;
+		margin: auto auto 12px auto;
+		text-align: center;
+	}
+	
+	.ssp-podcast-episode-count {
+		font-size: 14px;
+	}
+	
+	.ssp-podcast-description {
+		font-size: 14px;
+	}
+}
+
+/* Tablet responsive design */
+@media (max-width: 1024px) and (min-width: 769px) {
+	/* Reduce 3 columns to 2 columns on tablet */
+	.ssp-podcasts-columns-3 {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+/* Clickability styles */
+.ssp-podcast-card-clickable {
+	position: relative;
+}
+
+.ssp-podcast-card-link {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 1;
+	text-decoration: none;
+	color: transparent;
+}
+
+.ssp-podcast-card-link:hover,
+.ssp-podcast-card-link:focus {
+	text-decoration: none;
+	color: transparent;
+	outline: 2px solid #6c5ce7;
+	outline-offset: 2px;
+}
+
+/* Ensure focus is visible for keyboard navigation */
+.ssp-podcast-card-link:focus-visible {
+	outline: 2px solid #6c5ce7;
+	outline-offset: 2px;
+}
+
+.ssp-podcast-card-clickable:hover {
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.ssp-podcast-title-link {
+	text-decoration: none;
+	color: inherit;
+}
+
+.ssp-podcast-title-link:hover,
+.ssp-podcast-title-link:focus {
+	text-decoration: none;
+	color: #495057;
+	outline: 2px solid #6c5ce7;
+	outline-offset: 2px;
+	border-radius: 2px;
+}
+
+.ssp-podcast-title-link:focus-visible {
+	outline: 2px solid #6c5ce7;
+	outline-offset: 2px;
+}
+
+.ssp-podcast-title-link .ssp-podcast-title {
+	margin: 0;
+	font-size: 24px;
+	font-weight: 700;
+	color: #6c5ce7;
+	line-height: 1.2;
+	transition: color 0.3s ease;
+}
+
+.ssp-podcast-title-link:hover .ssp-podcast-title {
+	color: #495057;
+}
+
+/* Screen reader only text */
+.ssp-sr-only {
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	padding: 0 !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	clip: rect(0, 0, 0, 0) !important;
+	white-space: nowrap !important;
+	border: 0 !important;
+}

--- a/assets/css/podcast-list.css
+++ b/assets/css/podcast-list.css
@@ -31,16 +31,17 @@
 
 .ssp-podcast-card {
 	display: flex;
-	background: #f8f9fa;
+	background: var(--ssp-podcast-card-bg, #f8f9fa);
 	border-radius: 8px;
 	padding: 16px;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-	transition: box-shadow 0.3s ease;
+	transition: box-shadow 0.3s ease, background-color 0.3s ease;
 	position: relative;
 }
 
 .ssp-podcast-card:hover {
 	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+	background: var(--ssp-podcast-card-hover-bg, #e9ecef);
 }
 
 .ssp-podcast-image {
@@ -96,51 +97,51 @@
 	margin: 0;
 	font-size: 24px;
 	font-weight: 700;
-	color: #6c5ce7;
+	color: var(--ssp-title-color, #6c5ce7);
 	line-height: 1.2;
 }
 
 .ssp-listen-now-button {
-	background: #343a40;
-	color: white;
+	background: var(--ssp-button-bg, #343a40);
+	color: var(--ssp-button-text, #ffffff);
 	text-decoration: none;
 	padding: 8px 16px;
 	border-radius: 4px;
 	font-size: 14px;
 	font-weight: 600;
 	white-space: nowrap;
-	transition: background-color 0.3s ease;
 	display: inline-block;
 	margin-top: auto;
 	margin-left: auto;
 	width: fit-content;
 	box-sizing: border-box;
+	transition: 0.3s ease;
 }
 
 .ssp-listen-now-button:hover,
 .ssp-listen-now-button:focus {
-	background: #495057;
-	color: white;
+	background: var(--ssp-button-hover-bg, #495057);
+	color: var(--ssp-button-text, #ffffff);
 	text-decoration: none;
-	outline: 2px solid #6c5ce7;
-	outline-offset: 2px;
+	outline: 1px solid var(--ssp-button-hover-bg, #495057);
+	outline-offset: 0px;
 }
 
 .ssp-listen-now-button:focus-visible {
-	outline: 2px solid #6c5ce7;
+	outline: 1px solid var(--ssp-title-color, #6c5ce7);
 	outline-offset: 2px;
 }
 
 .ssp-podcast-episode-count {
 	font-size: 16px;
-	color: #6c757d;
+	color: var(--ssp-episode-count-color, #6c757d);
 	margin-bottom: 8px;
 	font-weight: 500;
 }
 
 .ssp-podcast-description {
 	font-size: 16px;
-	color: #6c757d;
+	color: var(--ssp-description-color, #6c757d);
 	line-height: 1.5;
 	margin: 0 0 16px 0;
 	text-align: justify;
@@ -256,7 +257,7 @@
 	margin: 0;
 	font-size: 24px;
 	font-weight: 700;
-	color: #6c5ce7;
+	color: var(--ssp-title-color, #6c5ce7);
 	line-height: 1.2;
 	transition: color 0.3s ease;
 }

--- a/assets/css/podcast-list.css
+++ b/assets/css/podcast-list.css
@@ -47,7 +47,7 @@
 .ssp-podcast-image {
 	flex-shrink: 0;
 	width: 120px;
-	height: 120px;
+	aspect-ratio: 1 / 1;
 	margin-right: 20px;
 	border-radius: 8px;
 	overflow: hidden;
@@ -55,6 +55,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	align-self: flex-start;
 }
 
 .ssp-podcast-image img {
@@ -101,7 +102,7 @@
 	line-height: 1.2;
 }
 
-.ssp-listen-now-button {
+.ssp-listen-now-button-content {
 	background: var(--ssp-button-bg, #343a40);
 	color: var(--ssp-button-text, #ffffff);
 	text-decoration: none;
@@ -118,8 +119,17 @@
 	transition: 0.3s ease;
 }
 
-.ssp-listen-now-button:hover,
-.ssp-listen-now-button:focus {
+/* When wrapped in <a> tag, the <a> tag should get the auto margins */
+a.ssp-listen-now-button {
+	margin-top: auto;
+	margin-left: auto;
+	width: fit-content;
+	text-decoration: none;
+}
+
+/* Hover animations only apply when there's a wrapper <a> tag */
+a.ssp-listen-now-button:hover .ssp-listen-now-button-content,
+a.ssp-listen-now-button:focus .ssp-listen-now-button-content {
 	background: var(--ssp-button-hover-bg, #495057);
 	color: var(--ssp-button-text, #ffffff);
 	text-decoration: none;
@@ -127,7 +137,7 @@
 	outline-offset: 0px;
 }
 
-.ssp-listen-now-button:focus-visible {
+a.ssp-listen-now-button:focus-visible .ssp-listen-now-button-content {
 	outline: 1px solid var(--ssp-title-color, #6c5ce7);
 	outline-offset: 2px;
 }
@@ -161,10 +171,9 @@
 	}
 	
 	.ssp-podcast-image {
-		width: 300px;
-		height: 300px;
-		max-width: 90%;
-		max-height: 90%;
+		width: 100%;
+		max-width: 300px;
+		aspect-ratio: 1 / 1;
 		margin: 0 auto 15px auto;
 	}
 	
@@ -173,11 +182,20 @@
 		text-align: center;
 	}
 	
-	.ssp-listen-now-button {
+	.ssp-listen-now-button-content {
 		font-size: 12px;
 		padding: 12px 12px;
+		width: 100%;
 		max-width: 300px;
-		width: 90%;
+		display: block;
+		margin: auto auto 12px auto;
+		text-align: center;
+	}
+	
+	/* When wrapped in <a> tag on mobile */
+	a.ssp-listen-now-button {
+		width: 100%;
+		max-width: 300px;
 		display: block;
 		margin: auto auto 12px auto;
 		text-align: center;
@@ -197,6 +215,21 @@
 	/* Reduce 3 columns to 2 columns on tablet */
 	.ssp-podcasts-columns-3 {
 		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+/* Middle screen range - force mobile layout for better image handling */
+@media (max-width: 900px) {
+	.ssp-podcast-card {
+		flex-direction: column;
+		text-align: center;
+	}
+	
+	.ssp-podcast-image {
+		width: 100%;
+		max-width: 300px;
+		aspect-ratio: 1 / 1;
+		margin: 0 auto 15px auto;
 	}
 }
 

--- a/php/classes/handlers/class-settings-handler.php
+++ b/php/classes/handlers/class-settings-handler.php
@@ -359,7 +359,7 @@ class Settings_Handler implements Service {
 
 		// For empty values, propagate some settings from the default feed
 		if ( ! isset( $data ) ) {
-			$propagate_exclusions = array( 'exclude_feed', 'redirect_feed' );
+			$propagate_exclusions = array( 'exclude_feed', 'redirect_feed', 'blocked' );
 			$propagated_types     = array( 'checkbox', 'select' );
 			$propagate            = in_array( $field['type'], $propagated_types, true ) &&
 									! in_array( $field['id'], $propagate_exclusions, true );

--- a/php/classes/shortcodes/class-podcast-list.php
+++ b/php/classes/shortcodes/class-podcast-list.php
@@ -180,7 +180,24 @@ class Podcast_List implements Shortcode {
 			return '';
 		}
 
-		return ssp_get_podcast_image_src( $term, 'medium' );
+		// First, try to get the podcast (series taxonomy) image
+		$podcast_image = ssp_get_podcast_image_src( $term, 'medium' );
+		
+		// If podcast image exists and is not the default no-image, use it
+		if ( ! empty( $podcast_image ) && false === strpos( $podcast_image, 'no-image.png' ) ) {
+			return $podcast_image;
+		}
+
+		// Fallback to feed image if podcast image is not available or is default
+		$settings_handler = ssp_get_service( 'settings_handler' );
+		$feed_image = $settings_handler->get_feed_image( $podcast_id );
+		
+		if ( ! empty( $feed_image ) ) {
+			return $feed_image;
+		}
+
+		// Final fallback to podcast image (even if it's the default no-image)
+		return $podcast_image;
 	}
 
 	/**

--- a/php/classes/shortcodes/class-podcast-list.php
+++ b/php/classes/shortcodes/class-podcast-list.php
@@ -101,7 +101,7 @@ class Podcast_List implements Shortcode {
 			'sort_by'             => 'id',
 			'sort'                => 'asc',
 			'clickable'           => 'button',
-			'hide_button'         => 'false',
+			'show_button'         => 'true',
 			'show_description'    => 'true',
 			'show_episode_count'  => 'true',
 			'description_words'   => 0,
@@ -111,6 +111,7 @@ class Podcast_List implements Shortcode {
 			'button_color'        => '#343a40',
 			'button_hover_color'  => '#495057',
 			'button_text_color'   => '#ffffff',
+			'button_text'         => __( 'Listen Now', 'seriously-simple-podcasting' ),
 			'title_color'         => '#6c5ce7',
 			'episode_count_color' => '#6c757d',
 			'description_color'   => '#6c757d',
@@ -126,7 +127,7 @@ class Podcast_List implements Shortcode {
 		$sort_by             = $this->validate_sort_by_parameter( $args['sort_by'] );
 		$sort                = $this->validate_sort_parameter( $args['sort'] );
 		$clickable           = $this->validate_clickable_parameter( $args['clickable'] );
-		$hide_button         = $this->validate_hide_button_parameter( $args['hide_button'] );
+		$show_button         = $this->validate_show_button_parameter( $args['show_button'] );
 		$show_description    = $this->validate_show_description_parameter( $args['show_description'] );
 		$show_episode_count  = $this->validate_show_episode_count_parameter( $args['show_episode_count'] );
 		$description_words   = $this->validate_description_words_parameter( $args['description_words'] );
@@ -136,18 +137,19 @@ class Podcast_List implements Shortcode {
 		$button_color        = $this->validate_background_parameter( $args['button_color'] );
 		$button_hover_color  = $this->validate_background_parameter( $args['button_hover_color'] );
 		$button_text_color   = $this->validate_background_parameter( $args['button_text_color'] );
+		$button_text         = $this->validate_button_text_parameter( $args['button_text'] );
 		$title_color         = $this->validate_background_parameter( $args['title_color'] );
 		$episode_count_color = $this->validate_background_parameter( $args['episode_count_color'] );
 		$description_color   = $this->validate_background_parameter( $args['description_color'] );
 
-		// Auto-adjustment: if hide_button=true and clickable=button, set clickable=title.
-		if ( $hide_button && 'button' === $clickable ) {
+		// Auto-adjustment: if show_button=false and clickable=button, set clickable=title.
+		if ( ! $show_button && 'button' === $clickable ) {
 			$clickable = 'title';
 		}
 
 		// Process display options for template.
-		$show_button   = ! $hide_button && 'button' === $clickable;
-		$wrapper_class = 'ssp-podcast-card';
+		$show_button_template = $show_button && 'button' === $clickable;
+		$wrapper_class        = 'ssp-podcast-card';
 		if ( 'card' === $clickable ) {
 			$wrapper_class .= ' ssp-podcast-card-clickable';
 		}
@@ -178,10 +180,10 @@ class Podcast_List implements Shortcode {
 			'podcasts'           => $podcasts,
 			'columns'            => $columns,
 			'clickable'          => $clickable,
-			'hide_button'        => $hide_button,
-			'show_button'        => $show_button,
+			'show_button'        => $show_button_template,
 			'show_description'   => $show_description,
 			'show_episode_count' => $show_episode_count,
+			'button_text'        => $button_text,
 			'wrapper_class'      => $wrapper_class,
 			'columns_class'      => $columns_class,
 			'css_vars'           => $css_vars,
@@ -438,16 +440,16 @@ class Podcast_List implements Shortcode {
 	}
 
 	/**
-	 * Validates and sanitizes the hide_button parameter to ensure it's a boolean.
+	 * Validates and sanitizes the show_button parameter to ensure it's a boolean.
 	 *
 	 * @since 3.13.0
 	 *
-	 * @param mixed $hide_button The hide_button parameter value.
-	 * @return bool Validated hide_button value.
+	 * @param mixed $show_button The show_button parameter value.
+	 * @return bool Validated show_button value.
 	 */
-	private function validate_hide_button_parameter( $hide_button ) {
+	private function validate_show_button_parameter( $show_button ) {
 		// Convert string values to boolean.
-		if ( 'true' === $hide_button || true === $hide_button || '1' === $hide_button || 1 === $hide_button ) {
+		if ( 'true' === $show_button || true === $show_button || '1' === $show_button || 1 === $show_button ) {
 			return true;
 		}
 
@@ -680,6 +682,22 @@ class Podcast_List implements Shortcode {
 
 		// Return sanitized hex color or default if invalid.
 		return ! empty( $sanitized_color ) ? $sanitized_color : '#f8f9fa';
+	}
+
+	/**
+	 * Validates and sanitizes the button text parameter.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param string $button_text The button text parameter.
+	 * @return string Sanitized button text.
+	 */
+	private function validate_button_text_parameter( $button_text ) {
+		// Sanitize the button text using WordPress sanitize_text_field function.
+		$sanitized_text = sanitize_text_field( $button_text );
+
+		// Return sanitized text or translatable default if empty.
+		return ! empty( $sanitized_text ) ? $sanitized_text : __( 'Listen Now', 'seriously-simple-podcasting' );
 	}
 
 	/**

--- a/php/classes/shortcodes/class-podcast-list.php
+++ b/php/classes/shortcodes/class-podcast-list.php
@@ -651,8 +651,12 @@ class Podcast_List implements Shortcode {
 		// Strip HTML tags for accurate character counting.
 		$stripped_text = wp_strip_all_tags( $text );
 
-		// Use WordPress native mb_strimwidth function for proper UTF-8 character truncation.
-		return mb_strimwidth( $stripped_text, 0, $limit, '…' );
+		// Prefer mb_strimwidth when available; otherwise fall back to wp_html_excerpt.
+		if ( function_exists( 'mb_strimwidth' ) ) {
+			return mb_strimwidth( $stripped_text, 0, $limit, '…' );
+		}
+		// wp_html_excerpt handles multibyte safely and appends the specified ellipsis.
+		return wp_html_excerpt( $stripped_text, $limit, '…' );
 	}
 
 	/**

--- a/php/classes/shortcodes/class-podcast-list.php
+++ b/php/classes/shortcodes/class-podcast-list.php
@@ -52,6 +52,38 @@ class Podcast_List implements Shortcode {
 	 */
 	public function __construct() {
 		$this->renderer = new Renderer();
+
+		// Register CSS assets.
+		add_action( 'wp_enqueue_scripts', array( $this, 'register_assets' ) );
+	}
+
+	/**
+	 * Registers CSS assets for the podcast list shortcode.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @return void
+	 */
+	public function register_assets() {
+		wp_register_style(
+			'ssp-podcast-list-shortcode',
+			esc_url( SSP_PLUGIN_URL . 'assets/css/podcast-list.css' ),
+			array(),
+			SSP_VERSION
+		);
+	}
+
+	/**
+	 * Enqueues CSS assets for the podcast list shortcode.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets() {
+		if ( ! wp_style_is( 'ssp-podcast-list-shortcode', 'enqueued' ) ) {
+			wp_enqueue_style( 'ssp-podcast-list-shortcode' );
+		}
 	}
 
 	/**
@@ -64,22 +96,75 @@ class Podcast_List implements Shortcode {
 	 */
 	public function shortcode( $params ) {
 		$defaults = array(
-			'ids'     => '',
-			'columns' => 1,
+			'ids'                => '',
+			'columns'            => 1,
+			'sort_by'            => 'id',
+			'sort'               => 'asc',
+			'clickable'          => 'button',
+			'hide_button'        => 'false',
+			'show_description'   => 'true',
+			'show_episode_count' => 'true',
+			'description_words'  => 0,
+			'description_chars'  => 0,
 		);
 
 		$args = shortcode_atts( $defaults, $params, 'ssp_podcasts' );
 
-		// Validate and sanitize columns parameter.
-		$columns = $this->validate_columns_parameter( $args['columns'] );
+		// Enqueue CSS only when shortcode is used.
+		$this->enqueue_assets();
+
+		// Validate and sanitize parameters.
+		$columns            = $this->validate_columns_parameter( $args['columns'] );
+		$sort_by            = $this->validate_sort_by_parameter( $args['sort_by'] );
+		$sort               = $this->validate_sort_parameter( $args['sort'] );
+		$clickable          = $this->validate_clickable_parameter( $args['clickable'] );
+		$hide_button        = $this->validate_hide_button_parameter( $args['hide_button'] );
+		$show_description   = $this->validate_show_description_parameter( $args['show_description'] );
+		$show_episode_count = $this->validate_show_episode_count_parameter( $args['show_episode_count'] );
+		$description_words  = $this->validate_description_words_parameter( $args['description_words'] );
+		$description_chars  = $this->validate_description_chars_parameter( $args['description_chars'] );
+
+		// Auto-adjustment: if hide_button=true and clickable=button, set clickable=title.
+		if ( $hide_button && 'button' === $clickable ) {
+			$clickable = 'title';
+		}
+
+		// Process display options for template.
+		$show_button   = ! $hide_button && 'button' === $clickable;
+		$wrapper_class = 'ssp-podcast-card';
+		if ( 'card' === $clickable ) {
+			$wrapper_class .= ' ssp-podcast-card-clickable';
+		}
+		$columns_class = 'ssp-podcasts-columns-' . $columns;
 
 		// Get podcasts based on IDs parameter.
-		$podcasts = $this->get_podcasts( $args['ids'] );
+		$podcasts = $this->get_podcasts( $args['ids'], $sort_by, $sort );
+
+		// Allow themes to filter podcast data before rendering.
+		$podcasts = array_map(
+			function ( $podcast, $index ) {
+				return apply_filters( 'ssp/podcast_list/card_data', $podcast, $index );
+			},
+			$podcasts,
+			array_keys( $podcasts )
+		);
+
+		// Process descriptions with truncation if needed.
+		if ( $show_description && ( $description_words > 0 || $description_chars > 0 ) ) {
+			$podcasts = $this->truncate_descriptions( $podcasts, $description_words, $description_chars );
+		}
 
 		// Prepare template data.
 		$template_data = array(
-			'podcasts' => $podcasts,
-			'columns'  => $columns,
+			'podcasts'           => $podcasts,
+			'columns'            => $columns,
+			'clickable'          => $clickable,
+			'hide_button'        => $hide_button,
+			'show_button'        => $show_button,
+			'show_description'   => $show_description,
+			'show_episode_count' => $show_episode_count,
+			'wrapper_class'      => $wrapper_class,
+			'columns_class'      => $columns_class,
 		);
 
 		// Render the template.
@@ -91,17 +176,80 @@ class Podcast_List implements Shortcode {
 	 *
 	 * @since 3.13.0
 	 *
-	 * @param string $ids Comma-separated podcast IDs.
+	 * @param string $ids     Comma-separated podcast IDs.
+	 * @param string $sort_by Sort by parameter (id, name, episode_count).
+	 * @param string $sort    Sort direction (asc, desc).
 	 * @return array Array of podcast data.
 	 */
-	private function get_podcasts( $ids = '' ) {
-		// Get all podcasts using existing function.
-		$podcasts = ssp_get_podcasts( false );
+	private function get_podcasts( $ids = '', $sort_by = 'id', $sort = 'asc' ) {
+		// Early return for specific IDs - ignore all other parameters.
+		if ( ! empty( $ids ) ) {
+			return $this->get_podcasts_by_ids( $ids );
+		}
 
-		// Filter by specific IDs if provided.
-		$podcasts = $this->filter_podcasts_by_ids( $podcasts, $ids );
+		// Prepare additional arguments for get_terms() based on sort_by parameter.
+		$additional_args = array();
+
+		// Use database-level sorting for ID and name sorting.
+		if ( 'id' === $sort_by || 'name' === $sort_by ) {
+			$additional_args['orderby'] = 'id' === $sort_by ? 'term_id' : 'name';
+			$additional_args['order']   = strtoupper( $sort );
+		}
+
+		// Get podcasts using existing function with additional args.
+		$podcasts = ssp_get_podcasts( false, $additional_args );
 
 		// Process each podcast into our data structure.
+		$podcasts_data = $this->process_podcasts_data( $podcasts );
+
+		// Sort podcasts for episode_count using PHP sorting.
+		if ( 'episode_count' === $sort_by ) {
+			$podcasts_data = $this->sort_podcasts( $podcasts_data, $sort_by, $sort );
+		}
+
+		return $podcasts_data;
+	}
+
+	/**
+	 * Retrieves and processes podcast data by specific IDs in exact order.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param string $ids Comma-separated podcast IDs.
+	 * @return array Array of podcast data in the exact order of provided IDs.
+	 */
+	private function get_podcasts_by_ids( $ids ) {
+		if ( empty( $ids ) ) {
+			return array();
+		}
+
+		$podcast_ids = array_map( 'intval', explode( ',', $ids ) );
+		$podcast_ids = array_filter( $podcast_ids );
+
+		if ( empty( $podcast_ids ) ) {
+			return array();
+		}
+
+		// Get podcasts by specific IDs using include parameter with exact order.
+		$additional_args = array(
+			'include' => $podcast_ids,
+			'orderby' => 'include', // Maintain exact order of IDs provided.
+		);
+		$podcasts        = ssp_get_podcasts( false, $additional_args );
+
+		// Process each podcast into our data structure.
+		return $this->process_podcasts_data( $podcasts );
+	}
+
+	/**
+	 * Processes podcast term objects into standardized data structure.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param array $podcasts Array of podcast term objects.
+	 * @return array Array of processed podcast data.
+	 */
+	private function process_podcasts_data( $podcasts ) {
 		$podcasts_data = array();
 		foreach ( $podcasts as $podcast ) {
 			if ( is_wp_error( $podcast ) ) {
@@ -122,6 +270,44 @@ class Podcast_List implements Shortcode {
 		}
 
 		return $podcasts_data;
+	}
+
+	/**
+	 * Sorts podcasts by the exact order of IDs provided.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param array  $podcasts_data Array of podcast data.
+	 * @param string $ids           Comma-separated podcast IDs.
+	 * @return array Sorted array of podcast data.
+	 */
+	private function sort_podcasts_by_ids_order( $podcasts_data, $ids ) {
+		if ( empty( $ids ) || empty( $podcasts_data ) ) {
+			return $podcasts_data;
+		}
+
+		$podcast_ids = array_map( 'intval', explode( ',', $ids ) );
+		$podcast_ids = array_filter( $podcast_ids );
+
+		if ( empty( $podcast_ids ) ) {
+			return $podcasts_data;
+		}
+
+		// Create a mapping of podcast ID to podcast data.
+		$podcasts_by_id = array();
+		foreach ( $podcasts_data as $podcast ) {
+			$podcasts_by_id[ $podcast['id'] ] = $podcast;
+		}
+
+		// Sort podcasts according to the order of IDs provided.
+		$sorted_podcasts = array();
+		foreach ( $podcast_ids as $id ) {
+			if ( isset( $podcasts_by_id[ $id ] ) ) {
+				$sorted_podcasts[] = $podcasts_by_id[ $id ];
+			}
+		}
+
+		return $sorted_podcasts;
 	}
 
 	/**
@@ -180,23 +366,23 @@ class Podcast_List implements Shortcode {
 			return '';
 		}
 
-		// First, try to get the podcast (series taxonomy) image
+		// First, try to get the podcast (series taxonomy) image.
 		$podcast_image = ssp_get_podcast_image_src( $term, 'medium' );
-		
-		// If podcast image exists and is not the default no-image, use it
+
+		// If podcast image exists and is not the default no-image, use it.
 		if ( ! empty( $podcast_image ) && false === strpos( $podcast_image, 'no-image.png' ) ) {
 			return $podcast_image;
 		}
 
-		// Fallback to feed image if podcast image is not available or is default
+		// Fallback to feed image if podcast image is not available or is default.
 		$settings_handler = ssp_get_service( 'settings_handler' );
-		$feed_image = $settings_handler->get_feed_image( $podcast_id );
-		
+		$feed_image       = $settings_handler->get_feed_image( $podcast_id );
+
 		if ( ! empty( $feed_image ) ) {
 			return $feed_image;
 		}
 
-		// Final fallback to podcast image (even if it's the default no-image)
+		// Final fallback to podcast image (even if it's the default no-image).
 		return $podcast_image;
 	}
 
@@ -213,6 +399,153 @@ class Podcast_List implements Shortcode {
 
 		// Return the URL or empty string if there's an error.
 		return is_wp_error( $url ) ? '' : $url;
+	}
+
+	/**
+	 * Validates and sanitizes the show_description parameter to ensure it's a boolean.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $show_description The show_description parameter value.
+	 * @return bool Validated show_description value.
+	 */
+	private function validate_show_description_parameter( $show_description ) {
+		// Convert string values to boolean.
+		if ( 'true' === $show_description || true === $show_description || '1' === $show_description || 1 === $show_description ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validates and sanitizes the show_episode_count parameter to ensure it's a boolean.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $show_episode_count The show_episode_count parameter value.
+	 * @return bool Validated show_episode_count value.
+	 */
+	private function validate_show_episode_count_parameter( $show_episode_count ) {
+		// Convert string values to boolean.
+		if ( 'true' === $show_episode_count || true === $show_episode_count || '1' === $show_episode_count || 1 === $show_episode_count ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validates and sanitizes the clickable parameter to ensure it's a valid option.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $clickable The clickable parameter value.
+	 * @return string Validated clickable value (button, card, title).
+	 */
+	private function validate_clickable_parameter( $clickable ) {
+		$valid_options = array( 'button', 'card', 'title' );
+
+		if ( in_array( $clickable, $valid_options, true ) ) {
+			return $clickable;
+		}
+
+		// Fall back to default if invalid.
+		return 'button';
+	}
+
+	/**
+	 * Validates and sanitizes the hide_button parameter to ensure it's a boolean.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $hide_button The hide_button parameter value.
+	 * @return bool Validated hide_button value.
+	 */
+	private function validate_hide_button_parameter( $hide_button ) {
+		// Convert string values to boolean.
+		if ( 'true' === $hide_button || true === $hide_button || '1' === $hide_button || 1 === $hide_button ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validates and sanitizes the sort_by parameter to ensure it's a valid option.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $sort_by The sort_by parameter value.
+	 * @return string Validated sort_by value (id, name, episode_count).
+	 */
+	private function validate_sort_by_parameter( $sort_by ) {
+		$valid_options = array( 'id', 'name', 'episode_count' );
+
+		if ( in_array( $sort_by, $valid_options, true ) ) {
+			return $sort_by;
+		}
+
+		// Fall back to default if invalid.
+		return 'id';
+	}
+
+	/**
+	 * Validates and sanitizes the sort parameter to ensure it's a valid direction.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $sort The sort parameter value.
+	 * @return string Validated sort value (asc, desc).
+	 */
+	private function validate_sort_parameter( $sort ) {
+		$valid_options = array( 'asc', 'desc' );
+
+		if ( in_array( $sort, $valid_options, true ) ) {
+			return $sort;
+		}
+
+		// Fall back to default if invalid.
+		return 'asc';
+	}
+
+	/**
+	 * Sorts podcast data array based on the specified criteria and direction.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param array  $podcasts_data Array of podcast data.
+	 * @param string $sort_by       Sort by parameter (id, name, episode_count).
+	 * @param string $sort          Sort direction (asc, desc).
+	 * @return array Sorted array of podcast data.
+	 */
+	private function sort_podcasts( $podcasts_data, $sort_by, $sort ) {
+		if ( empty( $podcasts_data ) ) {
+			return $podcasts_data;
+		}
+
+		// Define the comparison function based on sort_by parameter.
+		$comparison_function = function ( $a, $b ) use ( $sort_by ) {
+			switch ( $sort_by ) {
+				case 'name':
+					return strcasecmp( $a['name'], $b['name'] );
+				case 'episode_count':
+					return $a['episode_count'] - $b['episode_count'];
+				case 'id':
+				default:
+					return $a['id'] - $b['id'];
+			}
+		};
+
+		// Sort the array.
+		usort( $podcasts_data, $comparison_function );
+
+		// Reverse the array if descending order is requested.
+		if ( 'desc' === $sort ) {
+			$podcasts_data = array_reverse( $podcasts_data );
+		}
+
+		return $podcasts_data;
 	}
 
 	/**
@@ -235,5 +568,109 @@ class Podcast_List implements Shortcode {
 		}
 
 		return $columns;
+	}
+
+	/**
+	 * Validates and sanitizes the description_words parameter to ensure it's a non-negative integer.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $description_words The description_words parameter value.
+	 * @return int Validated description_words value (0 or positive integer).
+	 */
+	private function validate_description_words_parameter( $description_words ) {
+		// Convert to integer and ensure it's non-negative.
+		$description_words = intval( $description_words );
+
+		// Ensure description_words is non-negative.
+		if ( $description_words < 0 ) {
+			$description_words = 0;
+		}
+
+		return $description_words;
+	}
+
+	/**
+	 * Validates and sanitizes the description_chars parameter to ensure it's a non-negative integer.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param mixed $description_chars The description_chars parameter value.
+	 * @return int Validated description_chars value (0 or positive integer).
+	 */
+	private function validate_description_chars_parameter( $description_chars ) {
+		// Convert to integer and ensure it's non-negative.
+		$description_chars = intval( $description_chars );
+
+		// Ensure description_chars is non-negative.
+		if ( $description_chars < 0 ) {
+			$description_chars = 0;
+		}
+
+		return $description_chars;
+	}
+
+	/**
+	 * Truncates podcast descriptions based on word or character limits using WordPress native functions.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param array $podcasts          Array of podcast data.
+	 * @param int   $description_words Maximum number of words (0 = no limit).
+	 * @param int   $description_chars Maximum number of characters (0 = no limit).
+	 * @return array Array of podcast data with truncated descriptions.
+	 */
+	private function truncate_descriptions( $podcasts, $description_words, $description_chars ) {
+		foreach ( $podcasts as $index => $podcast ) {
+			if ( empty( $podcast['description'] ) ) {
+				continue;
+			}
+
+			$description = $podcast['description'];
+
+			// Priority: description_chars > description_words.
+			if ( $description_chars > 0 ) {
+				// Use WordPress native function for character-based truncation.
+				$description = $this->truncate_by_characters( $description, $description_chars );
+			} elseif ( $description_words > 0 ) {
+				// Use WordPress native function for word-based truncation.
+				$description = $this->truncate_by_words( $description, $description_words );
+			}
+
+			$podcasts[ $index ]['description'] = $description;
+		}
+
+		return $podcasts;
+	}
+
+	/**
+	 * Truncates text by character count using WordPress native functions.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param string $text  Text to truncate.
+	 * @param int    $limit Maximum number of characters.
+	 * @return string Truncated text.
+	 */
+	private function truncate_by_characters( $text, $limit ) {
+		// Strip HTML tags for accurate character counting.
+		$stripped_text = wp_strip_all_tags( $text );
+
+		// Use WordPress native mb_strimwidth function for proper UTF-8 character truncation.
+		return mb_strimwidth( $stripped_text, 0, $limit, '…' );
+	}
+
+	/**
+	 * Truncates text by word count using WordPress native functions.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param string $text  Text to truncate.
+	 * @param int    $limit Maximum number of words.
+	 * @return string Truncated text.
+	 */
+	private function truncate_by_words( $text, $limit ) {
+		// Use WordPress native wp_trim_words function for proper word truncation.
+		return wp_trim_words( $text, $limit, '…' );
 	}
 }

--- a/php/classes/shortcodes/class-podcast-list.php
+++ b/php/classes/shortcodes/class-podcast-list.php
@@ -295,35 +295,6 @@ class Podcast_List implements Shortcode {
 
 
 	/**
-	 * Filters podcast collection to include only specified IDs.
-	 *
-	 * @since 3.13.0
-	 *
-	 * @param array  $podcasts Array of podcast term objects.
-	 * @param string $ids      Comma-separated podcast IDs.
-	 * @return array Filtered array of podcast term objects.
-	 */
-	private function filter_podcasts_by_ids( $podcasts, $ids ) {
-		if ( empty( $ids ) ) {
-			return $podcasts;
-		}
-
-		$podcast_ids = array_map( 'intval', explode( ',', $ids ) );
-		$podcast_ids = array_filter( $podcast_ids );
-
-		if ( empty( $podcast_ids ) ) {
-			return array();
-		}
-
-		return array_filter(
-			$podcasts,
-			function ( $podcast ) use ( $podcast_ids ) {
-				return in_array( $podcast->term_id, $podcast_ids, true );
-			}
-		);
-	}
-
-	/**
 	 * Counts published episodes for a specific podcast.
 	 *
 	 * @since 3.13.0
@@ -458,12 +429,13 @@ class Podcast_List implements Shortcode {
 	 * @return bool Validated show_button value.
 	 */
 	private function validate_show_button_parameter( $show_button ) {
-		// Convert string values to boolean.
-		if ( 'true' === $show_button || true === $show_button || '1' === $show_button || 1 === $show_button ) {
-			return true;
+		// Explicitly false values
+		if ( 'false' === $show_button || false === $show_button || '0' === $show_button || 0 === $show_button ) {
+			return false;
 		}
 
-		return false;
+		// For everything else (true values, invalid values, empty values), fall back to default (true)
+		return true;
 	}
 
 	/**

--- a/php/config/settings/feed.php
+++ b/php/config/settings/feed.php
@@ -267,7 +267,7 @@ $feed_fields = array(
 	array(
 		'id'          => 'blocked',
 		'label'       => __( 'Mark removed', 'seriously-simple-podcasting' ),
-		'description' => __( 'Mark this feed to be removed from iTunes. When enabled, adds the itunes:block tag to the feed.', 'seriously-simple-podcasting' ),
+		'description' => __( 'Mark this feed to be removed from Apple Podcasts. When enabled, adds the itunes:block tag to the feed.', 'seriously-simple-podcasting' ),
 		'type'        => 'checkbox',
 		'default'     => '',
 		'callback'    => 'wp_strip_all_tags',

--- a/php/includes/ssp-functions.php
+++ b/php/includes/ssp-functions.php
@@ -1726,8 +1726,9 @@ if ( ! function_exists( 'ssp_get_podcasts' ) ) {
 		// Allow filtering of the arguments before querying.
 		$args = apply_filters( 'ssp_get_podcasts_args', $args, $hide_empty, $additional_args );
 
-		// Create cache key based on filtered arguments.
-		$cache_key   = 'ssp_podcasts_' . md5( serialize( $args ) );
+		$taxonomy    = ssp_series_taxonomy();
+		// Create cache key based on taxonomy + filtered arguments.
+		$cache_key   = 'ssp_podcasts_' . $taxonomy . '_' . md5( serialize( $args ) );
 		$cache_group = 'ssp';
 		$podcasts    = wp_cache_get( $cache_key, $cache_group );
 
@@ -1737,7 +1738,7 @@ if ( ! function_exists( 'ssp_get_podcasts' ) ) {
 		}
 
 		// Fetch podcasts and store in cache.
-		$podcasts = get_terms( ssp_series_taxonomy(), $args );
+		$podcasts = get_terms( $taxonomy, $args );
 		wp_cache_set( $cache_key, $podcasts, $cache_group, HOUR_IN_SECONDS );
 
 		return is_array( $podcasts ) ? $podcasts : array();

--- a/php/includes/ssp-functions.php
+++ b/php/includes/ssp-functions.php
@@ -2108,7 +2108,7 @@ if ( ! function_exists( 'ssp_episode_guid' ) ) {
 	 *
 	 * @param int $episode_id Episode ID.
 	 *
-	 * @return int The episode guid.
+	 * @return string The episode guid.
 	 */
 	function ssp_episode_guid( $episode_id = 0 ) {
 		if ( ! $episode_id ) {

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.13.0-alpha
+ * Version: 3.13.0-alpha.2
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.13.0-alpha' );
+define( 'SSP_VERSION', '3.13.0-alpha.2' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/src/components/SSPSidebarPanel.js
+++ b/src/components/SSPSidebarPanel.js
@@ -1,7 +1,7 @@
 import { PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import FileIsUploadedSvg from '../img/file-is-uploaded.svg';
 import FileNotUploadedSvg from '../img/file-not-uploaded.svg';
@@ -14,6 +14,23 @@ const SSPSidebarPanel = () => {
 	}
 
 	const [isSSPSectionOpen, setSSPSectionOpen] = useState(true);
+	
+	// Track post save state to refresh meta data
+	const isSavingPost = useSelect((select) => select('core/editor').isSavingPost(), []);
+	const previousIsSaving = useRef(isSavingPost);
+	const isPostJustSaved = previousIsSaving.current && !isSavingPost;
+	previousIsSaving.current = isSavingPost;
+	
+	// Force re-render when post is saved to refresh meta data
+	const [refreshTrigger, setRefreshTrigger] = useState(0);
+	
+	useEffect(() => {
+		if (isPostJustSaved) {
+			// Trigger a re-render to refresh the post meta data
+			setRefreshTrigger(prev => prev + 1);
+		}
+	}, [isPostJustSaved]);
+	
 	const postMeta = editor.getEditedPostAttribute('meta');
 
 	if ( ! postMeta ) {

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -103,7 +103,7 @@ if ( $stylesheet_url ) {
 		<?php endif; ?></itunes:owner>
 		<itunes:explicit><?php echo esc_html( $itunes_explicit ); ?></itunes:explicit>
 		<?php if ( $is_blocked ) :
-			?><itunes:block>yes</itunes:block>
+			?><itunes:block>Yes</itunes:block>
 		<?php endif;
 		if ( $complete ) :
 			?><itunes:complete><?php echo esc_html( $complete ); ?></itunes:complete>

--- a/templates/podcast-list.php
+++ b/templates/podcast-list.php
@@ -7,10 +7,10 @@
  * @var array  $podcasts           Array of podcast data with keys: name, url, cover_image, description, episode_count
  * @var int    $columns            Number of columns for the grid layout (1-3)
  * @var string $clickable          Clickability mode: 'button', 'card', or 'title'
- * @var bool   $hide_button        Whether to hide the listen button
  * @var bool   $show_button        Whether to show the listen button (pre-processed)
  * @var bool   $show_description   Whether to show podcast descriptions
  * @var bool   $show_episode_count Whether to show episode counts
+ * @var string $button_text        Custom text for the listen button
  * @var string $wrapper_class      CSS class for podcast cards (pre-processed)
  * @var string $columns_class      CSS class for grid columns (pre-processed)
  * @var int    $description_words  Maximum number of words for descriptions (pre-processed)
@@ -117,10 +117,7 @@ if ( empty( $podcasts ) || ! is_array( $podcasts ) ) {
 					<a href="<?php echo esc_url( $podcast_url ); ?>" 
 						class="ssp-listen-now-button" 
 						aria-label="<?php echo esc_attr( sprintf( __( 'Listen to %s podcast', 'seriously-simple-podcasting' ), $podcast_name ) ); ?>">
-						<?php
-						/* translators: Button text to listen to a podcast */
-						echo esc_html__( 'Listen Now', 'seriously-simple-podcasting' );
-						?>
+						<?php echo esc_html( $button_text ); ?>
 						→
 					</a>
 				<?php endif; ?>

--- a/templates/podcast-list.php
+++ b/templates/podcast-list.php
@@ -1,6 +1,11 @@
 <?php
 /**
  * Podcast List Template
+ * 
+ * @see SeriouslySimplePodcasting\ShortCodes\Podcast_List::shortcode()
+ * 
+ * @var array $podcasts
+ * @var int $columns
  *
  * @package SeriouslySimplePodcasting
  * @since 3.13.0

--- a/templates/podcast-list.php
+++ b/templates/podcast-list.php
@@ -49,7 +49,13 @@ if ( empty( $podcasts ) || ! is_array( $podcasts ) ) {
 // All display options are now pre-processed in the shortcode class
 ?>
 
-<?php do_action( 'ssp/podcast_list/before', $podcasts, $columns ); ?>
+<?php
+/**
+ * @action `ssp/podcast_list/before` Fires before the podcast list container
+ * @param array $podcasts Array of podcast data
+ * @param int   $columns  Number of columns in the grid
+ */
+do_action( 'ssp/podcast_list/before', $podcasts, $columns ); ?>
 
 <div class="ssp-podcasts <?php echo esc_attr( $columns_class ); ?>" role="region" aria-label="<?php esc_attr_e( 'Podcast List', 'seriously-simple-podcasting' ); ?>"<?php echo ! empty( $css_vars ) ? ' style="' . esc_attr( $css_vars ) . '"' : ''; ?>>
 	<?php foreach ( $podcasts as $index => $podcast ) : ?>
@@ -62,7 +68,13 @@ if ( empty( $podcasts ) || ! is_array( $podcasts ) ) {
 		$podcast_name       = isset( $podcast['name'] ) ? $podcast['name'] : '';
 
 		?>
-		<?php do_action( 'ssp/podcast_list/card/before', $podcast, $index ); ?>
+		<?php
+		/**
+		 * @action `ssp/podcast_list/card/before` Fires before each podcast card
+		 * @param array $podcast Podcast data array
+		 * @param int   $index   Current podcast index in the loop
+		 */
+		do_action( 'ssp/podcast_list/card/before', $podcast, $index ); ?>
 		<div class="<?php echo esc_attr( $wrapper_class ); ?>" role="article">
 			<?php if ( $card_is_clickable ) : ?>
 				<!-- Absolutely positioned link that covers the entire card -->
@@ -71,7 +83,13 @@ if ( empty( $podcasts ) || ! is_array( $podcasts ) ) {
 					aria-label="<?php echo esc_attr( sprintf( __( 'View %s podcast details', 'seriously-simple-podcasting' ), $podcast_name ) ); ?>"></a>
 			<?php endif; ?>
 			
-			<?php do_action( 'ssp/podcast_list/image/before', $podcast, $index ); ?>
+			<?php
+			/**
+			 * @action `ssp/podcast_list/image/before` Fires before each podcast image
+			 * @param array $podcast Podcast data array
+			 * @param int   $index   Current podcast index in the loop
+			 */
+			do_action( 'ssp/podcast_list/image/before', $podcast, $index ); ?>
 			<div class="ssp-podcast-image" role="img" aria-label="<?php echo esc_attr( sprintf( __( 'Cover image for %s', 'seriously-simple-podcasting' ), $podcast_name ) ); ?>">
 				<?php if ( $cover_image ) : ?>
 					<img src="<?php echo esc_url( $cover_image ); ?>" 
@@ -83,9 +101,21 @@ if ( empty( $podcasts ) || ! is_array( $podcasts ) ) {
 					</div>
 				<?php endif; ?>
 			</div>
-			<?php do_action( 'ssp/podcast_list/image/after', $podcast, $index ); ?>
+			<?php
+			/**
+			 * @action `ssp/podcast_list/image/after` Fires after each podcast image
+			 * @param array $podcast Podcast data array
+			 * @param int   $index   Current podcast index in the loop
+			 */
+			do_action( 'ssp/podcast_list/image/after', $podcast, $index ); ?>
 			
-			<?php do_action( 'ssp/podcast_list/content/before', $podcast, $index ); ?>
+			<?php
+			/**
+			 * @action `ssp/podcast_list/content/before` Fires before each podcast content area
+			 * @param array $podcast Podcast data array
+			 * @param int   $index   Current podcast index in the loop
+			 */
+			do_action( 'ssp/podcast_list/content/before', $podcast, $index ); ?>
 			<div class="ssp-podcast-content">
 				<div class="ssp-podcast-header">
 					<?php if ( $title_is_clickable ) : ?>
@@ -114,18 +144,40 @@ if ( empty( $podcasts ) || ! is_array( $podcasts ) ) {
 				<?php endif; ?>
 				
 				<?php if ( $show_button && ! empty( $podcast_url ) ) : ?>
-					<a href="<?php echo esc_url( $podcast_url ); ?>" 
-						class="ssp-listen-now-button" 
-						aria-label="<?php echo esc_attr( sprintf( __( 'Listen to %s podcast', 'seriously-simple-podcasting' ), $podcast_name ) ); ?>">
-						<?php echo esc_html( $button_text ); ?>
-						→
-					</a>
+					<?php if ( ! $card_is_clickable ) : ?>
+						<a href="<?php echo esc_url( $podcast_url ); 
+						?>" class="ssp-listen-now-button" aria-label="<?php 
+						echo esc_attr( sprintf( __( 'Listen to %s podcast', 'seriously-simple-podcasting' ), $podcast_name ) ); ?>">
+					<?php endif; ?>
+						<span class="ssp-listen-now-button-content">
+							<?php echo esc_html( $button_text ); ?>
+							→
+						</span>
+					<?php if ( ! $card_is_clickable ) : ?></a><?php endif; ?>
 				<?php endif; ?>
 			</div>
-			<?php do_action( 'ssp/podcast_list/content/after', $podcast, $index ); ?>
+			<?php
+			/**
+			 * @action `ssp/podcast_list/content/after` Fires after each podcast content area
+			 * @param array $podcast Podcast data array
+			 * @param int   $index   Current podcast index in the loop
+			 */
+			do_action( 'ssp/podcast_list/content/after', $podcast, $index ); ?>
 		</div>
-		<?php do_action( 'ssp/podcast_list/card/after', $podcast, $index ); ?>
+		<?php
+		/**
+		 * @action `ssp/podcast_list/card/after` Fires after each podcast card
+		 * @param array $podcast Podcast data array
+		 * @param int   $index   Current podcast index in the loop
+		 */
+		do_action( 'ssp/podcast_list/card/after', $podcast, $index ); ?>
 	<?php endforeach; ?>
 </div>
 
-<?php do_action( 'ssp/podcast_list/after', $podcasts, $columns ); ?>
+<?php
+/**
+ * @action `ssp/podcast_list/after` Fires after the podcast list container
+ * @param array $podcasts Array of podcast data
+ * @param int   $columns  Number of columns in the grid
+ */
+do_action( 'ssp/podcast_list/after', $podcasts, $columns ); ?>

--- a/templates/podcast-list.php
+++ b/templates/podcast-list.php
@@ -15,6 +15,7 @@
  * @var string $columns_class      CSS class for grid columns (pre-processed)
  * @var int    $description_words  Maximum number of words for descriptions (pre-processed)
  * @var int    $description_chars  Maximum number of characters for descriptions (pre-processed)
+ * @var string $css_vars           CSS variables for background colors (pre-processed)
  *
  * Available Hooks:
  * - ssp/podcast_list/before: Before the entire podcast list
@@ -50,7 +51,7 @@ if ( empty( $podcasts ) || ! is_array( $podcasts ) ) {
 
 <?php do_action( 'ssp/podcast_list/before', $podcasts, $columns ); ?>
 
-<div class="ssp-podcasts <?php echo esc_attr( $columns_class ); ?>" role="region" aria-label="<?php esc_attr_e( 'Podcast List', 'seriously-simple-podcasting' ); ?>">
+<div class="ssp-podcasts <?php echo esc_attr( $columns_class ); ?>" role="region" aria-label="<?php esc_attr_e( 'Podcast List', 'seriously-simple-podcasting' ); ?>"<?php echo ! empty( $css_vars ) ? ' style="' . esc_attr( $css_vars ) . '"' : ''; ?>>
 	<?php foreach ( $podcasts as $index => $podcast ) : ?>
 		<?php
 		// Get podcast-specific data

--- a/templates/podcast-list.php
+++ b/templates/podcast-list.php
@@ -150,8 +150,7 @@ do_action( 'ssp/podcast_list/before', $podcasts, $columns ); ?>
 						echo esc_attr( sprintf( __( 'Listen to %s podcast', 'seriously-simple-podcasting' ), $podcast_name ) ); ?>">
 					<?php endif; ?>
 						<span class="ssp-listen-now-button-content">
-							<?php echo esc_html( $button_text ); ?>
-							→
+							<?php echo esc_html( $button_text ); ?> →
 						</span>
 					<?php if ( ! $card_is_clickable ) : ?></a><?php endif; ?>
 				<?php endif; ?>

--- a/tests/wpunit/Podcast_List_Test.php
+++ b/tests/wpunit/Podcast_List_Test.php
@@ -228,6 +228,14 @@ class Podcast_List_Test extends WPTestCase {
 			'slug'     => 'test-podcast'
 		) );
 
+		// Create test episode for the series
+		$episode = $this->factory->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Episode'
+		) );
+		wp_set_post_terms( $episode, array( $series ), 'series' );
+
 		// Create the shortcode instance
 		$podcast_list = new Podcast_List();
 		
@@ -253,6 +261,14 @@ class Podcast_List_Test extends WPTestCase {
 			'name'     => 'Test Podcast',
 			'slug'     => 'test-podcast'
 		) );
+
+		// Create test episode for the series
+		$episode = $this->factory->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Episode'
+		) );
+		wp_set_post_terms( $episode, array( $series ), 'series' );
 
 		// Create the shortcode instance
 		$podcast_list = new Podcast_List();
@@ -521,9 +537,9 @@ class Podcast_List_Test extends WPTestCase {
 
 	/**
 	 * @covers Podcast_List::shortcode()
-	 * Test auto-adjustment: if hide_button=true and clickable=button, set clickable=title
+	 * Test auto-adjustment: if show_button=false and clickable=button, set clickable=title
 	 */
-	public function test_auto_adjustment_hide_button_and_clickable_button() {
+	public function test_auto_adjustment_show_button_false_and_clickable_button() {
 		// Create test podcast series
 		$series = $this->factory->term->create( array(
 			'taxonomy' => 'series',
@@ -531,17 +547,25 @@ class Podcast_List_Test extends WPTestCase {
 			'slug'     => 'test-podcast'
 		) );
 
+		// Create test episode for the series
+		$episode = $this->factory->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Episode'
+		) );
+		wp_set_post_terms( $episode, array( $series ), 'series' );
+
 		// Create the shortcode instance
 		$podcast_list = new Podcast_List();
 		
-		// Test auto-adjustment when hide_button=true and clickable=button
+		// Test auto-adjustment when show_button=false and clickable=button
 		$output = $podcast_list->shortcode( array( 
 			'ids' => $series,
 			'clickable' => 'button',
-			'hide_button' => 'true'
+			'show_button' => 'false'
 		) );
 		
-		// Should not contain the actual listen now button element (because hide_button=true)
+		// Should not contain the actual listen now button element (because show_button=false)
 		$this->assertStringNotContainsString( 'Listen Now →', $output );
 		// Should contain title clickability instead
 		$this->assertStringContainsString( 'ssp-podcast-title-link', $output );
@@ -924,6 +948,14 @@ class Podcast_List_Test extends WPTestCase {
 			'description' => 'This is a très long podcast description with spécial characters like café, naïve, and résumé for testing UTF-8 handling'
 		) );
 
+		// Create test episode for the series
+		$episode = $this->factory->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Episode'
+		) );
+		wp_set_post_terms( $episode, array( $series ), 'series' );
+
 		// Create the shortcode instance
 		$podcast_list = new Podcast_List();
 		
@@ -934,6 +966,6 @@ class Podcast_List_Test extends WPTestCase {
 		) );
 		
 		// Should handle UTF-8 characters properly
-		$this->assertStringContainsString( 'This is a très long podcast description with spé…', $output_chars );
+		$this->assertStringContainsString( 'This is a très long podcast description with spéc…', $output_chars );
 	}
 }

--- a/tests/wpunit/Podcast_List_Test.php
+++ b/tests/wpunit/Podcast_List_Test.php
@@ -302,4 +302,638 @@ class Podcast_List_Test extends WPTestCase {
 		$this->assertStringContainsString( 'Test Podcast 1', $output );
 		$this->assertStringContainsString( 'Test Podcast 2', $output );
 	}
+
+	/**
+	 * @covers Podcast_List::validate_sort_by_parameter()
+	 * Test sort_by parameter validation with valid values
+	 */
+	public function test_sort_by_parameter_validation() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with valid sort_by values
+		$output_id = $podcast_list->shortcode( array( 'sort_by' => 'id' ) );
+		$output_name = $podcast_list->shortcode( array( 'sort_by' => 'name' ) );
+		$output_episode_count = $podcast_list->shortcode( array( 'sort_by' => 'episode_count' ) );
+		
+		// All should work without errors
+		$this->assertStringContainsString( 'ssp-podcasts', $output_id );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_name );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_episode_count );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_sort_by_parameter()
+	 * Test sort_by parameter validation with invalid values (should fall back to default)
+	 */
+	public function test_sort_by_parameter_invalid_values() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with invalid sort_by values (should fall back to 'id')
+		$output_invalid = $podcast_list->shortcode( array( 'sort_by' => 'invalid' ) );
+		$output_empty = $podcast_list->shortcode( array( 'sort_by' => '' ) );
+		$output_number = $podcast_list->shortcode( array( 'sort_by' => '123' ) );
+		
+		// All should work without errors (fallback to default)
+		$this->assertStringContainsString( 'ssp-podcasts', $output_invalid );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_empty );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_number );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_sort_parameter()
+	 * Test sort parameter validation with valid values
+	 */
+	public function test_sort_parameter_validation() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with valid sort values
+		$output_asc = $podcast_list->shortcode( array( 'sort' => 'asc' ) );
+		$output_desc = $podcast_list->shortcode( array( 'sort' => 'desc' ) );
+		
+		// All should work without errors
+		$this->assertStringContainsString( 'ssp-podcasts', $output_asc );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_desc );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_sort_parameter()
+	 * Test sort parameter validation with invalid values (should fall back to default)
+	 */
+	public function test_sort_parameter_invalid_values() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with invalid sort values (should fall back to 'asc')
+		$output_invalid = $podcast_list->shortcode( array( 'sort' => 'invalid' ) );
+		$output_empty = $podcast_list->shortcode( array( 'sort' => '' ) );
+		$output_number = $podcast_list->shortcode( array( 'sort' => '123' ) );
+		
+		// All should work without errors (fallback to default)
+		$this->assertStringContainsString( 'ssp-podcasts', $output_invalid );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_empty );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_number );
+	}
+
+	/**
+	 * @covers Podcast_List::shortcode()
+	 * Test sorting is ignored when ids parameter is specified
+	 */
+	public function test_sorting_ignored_with_ids() {
+		// Create test podcast series with different names for sorting
+		$series1 = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Zebra Podcast',
+			'slug'     => 'zebra-podcast'
+		) );
+		
+		$series2 = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Apple Podcast',
+			'slug'     => 'apple-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test that when ids are specified, sorting is ignored (order should be by ids order)
+		$output = $podcast_list->shortcode( array( 
+			'ids' => $series1 . ',' . $series2,
+			'sort_by' => 'name',
+			'sort' => 'asc'
+		) );
+		
+		// Should contain both podcasts
+		$this->assertStringContainsString( 'Zebra Podcast', $output );
+		$this->assertStringContainsString( 'Apple Podcast', $output );
+		// The exact order depends on the IDs parameter, not the sorting
+	}
+
+	/**
+	 * @covers Podcast_List::validate_clickable_parameter()
+	 * Test clickable parameter validation with valid values
+	 */
+	public function test_clickable_parameter_validation() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with valid clickable values
+		$output_button = $podcast_list->shortcode( array( 'clickable' => 'button' ) );
+		$output_card = $podcast_list->shortcode( array( 'clickable' => 'card' ) );
+		$output_title = $podcast_list->shortcode( array( 'clickable' => 'title' ) );
+		
+		// All should work without errors
+		$this->assertStringContainsString( 'ssp-podcasts', $output_button );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_card );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_title );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_clickable_parameter()
+	 * Test clickable parameter validation with invalid values (should fall back to default)
+	 */
+	public function test_clickable_parameter_invalid_values() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with invalid clickable values (should fall back to 'button')
+		$output_invalid = $podcast_list->shortcode( array( 'clickable' => 'invalid' ) );
+		$output_empty = $podcast_list->shortcode( array( 'clickable' => '' ) );
+		$output_number = $podcast_list->shortcode( array( 'clickable' => '123' ) );
+		
+		// All should work without errors (fallback to default)
+		$this->assertStringContainsString( 'ssp-podcasts', $output_invalid );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_empty );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_number );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_hide_button_parameter()
+	 * Test hide_button parameter validation with various boolean values
+	 */
+	public function test_hide_button_parameter_validation() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with various boolean values
+		$output_true = $podcast_list->shortcode( array( 'hide_button' => 'true' ) );
+		$output_false = $podcast_list->shortcode( array( 'hide_button' => 'false' ) );
+		$output_1 = $podcast_list->shortcode( array( 'hide_button' => '1' ) );
+		$output_0 = $podcast_list->shortcode( array( 'hide_button' => '0' ) );
+		
+		// All should work without errors
+		$this->assertStringContainsString( 'ssp-podcasts', $output_true );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_false );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_1 );
+		$this->assertStringContainsString( 'ssp-podcasts', $output_0 );
+	}
+
+	/**
+	 * @covers Podcast_List::shortcode()
+	 * Test auto-adjustment: if hide_button=true and clickable=button, set clickable=title
+	 */
+	public function test_auto_adjustment_hide_button_and_clickable_button() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test auto-adjustment when hide_button=true and clickable=button
+		$output = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'clickable' => 'button',
+			'hide_button' => 'true'
+		) );
+		
+		// Should not contain the actual listen now button element (because hide_button=true)
+		$this->assertStringNotContainsString( 'Listen Now →', $output );
+		// Should contain title clickability instead
+		$this->assertStringContainsString( 'ssp-podcast-title-link', $output );
+		// Should work without errors
+		$this->assertStringContainsString( 'ssp-podcasts', $output );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_show_description_parameter()
+	 * Test show_description parameter validation with various boolean values
+	 */
+	public function test_show_description_parameter_validation() {
+		// Create test podcast series with description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a test podcast description'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with various boolean values
+		$output_true = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => 'true'
+		) );
+		$output_false = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => 'false'
+		) );
+		$output_1 = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => '1'
+		) );
+		$output_0 = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => '0'
+		) );
+		
+		// Test that description is shown when true
+		$this->assertStringContainsString( 'This is a test podcast description', $output_true );
+		$this->assertStringContainsString( 'This is a test podcast description', $output_1 );
+		
+		// Test that description is hidden when false
+		$this->assertStringNotContainsString( 'This is a test podcast description', $output_false );
+		$this->assertStringNotContainsString( 'This is a test podcast description', $output_0 );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_show_episode_count_parameter()
+	 * Test show_episode_count parameter validation with various boolean values
+	 */
+	public function test_show_episode_count_parameter_validation() {
+		// Create test podcast series
+		$series = $this->factory->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Test Podcast',
+			'slug'     => 'test-podcast'
+		) );
+
+		// Create an episode for the series
+		$episode = $this->factory->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Episode'
+		) );
+		wp_set_post_terms( $episode, array( $series ), 'series' );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with various boolean values
+		$output_true = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_episode_count' => 'true'
+		) );
+		$output_false = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_episode_count' => 'false'
+		) );
+		$output_1 = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_episode_count' => '1'
+		) );
+		$output_0 = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_episode_count' => '0'
+		) );
+		
+		// Test that episode count is shown when true
+		$this->assertStringContainsString( '1 episode', $output_true );
+		$this->assertStringContainsString( '1 episode', $output_1 );
+		
+		// Test that episode count is hidden when false
+		$this->assertStringNotContainsString( '1 episode', $output_false );
+		$this->assertStringNotContainsString( '1 episode', $output_0 );
+	}
+
+	/**
+	 * @covers Podcast_List::shortcode()
+	 * Test display controls with various combinations
+	 */
+	public function test_display_controls_combinations() {
+		// Create test podcast series with description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a test podcast description'
+		) );
+
+		// Create an episode for the series
+		$episode = $this->factory->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Episode'
+		) );
+		wp_set_post_terms( $episode, array( $series ), 'series' );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test with both description and episode count hidden
+		$output_both_hidden = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => 'false',
+			'show_episode_count' => 'false'
+		) );
+		
+		// Test with description hidden but episode count shown
+		$output_desc_hidden = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => 'false',
+			'show_episode_count' => 'true'
+		) );
+		
+		// Test with episode count hidden but description shown
+		$output_count_hidden = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => 'true',
+			'show_episode_count' => 'false'
+		) );
+		
+		// Test with both shown (default behavior)
+		$output_both_shown = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'show_description' => 'true',
+			'show_episode_count' => 'true'
+		) );
+		
+		// Verify both hidden
+		$this->assertStringNotContainsString( 'This is a test podcast description', $output_both_hidden );
+		$this->assertStringNotContainsString( '1 episode', $output_both_hidden );
+		
+		// Verify description hidden, episode count shown
+		$this->assertStringNotContainsString( 'This is a test podcast description', $output_desc_hidden );
+		$this->assertStringContainsString( '1 episode', $output_desc_hidden );
+		
+		// Verify episode count hidden, description shown
+		$this->assertStringContainsString( 'This is a test podcast description', $output_count_hidden );
+		$this->assertStringNotContainsString( '1 episode', $output_count_hidden );
+		
+		// Verify both shown
+		$this->assertStringContainsString( 'This is a test podcast description', $output_both_shown );
+		$this->assertStringContainsString( '1 episode', $output_both_shown );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_description_words_parameter()
+	 * Test description_words parameter validation with valid values
+	 */
+	public function test_description_words_parameter_validation() {
+		// Create test podcast series with long description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a very long test podcast description that contains many words to test the word truncation functionality properly'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with different word limits
+		$output_5_words = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_words' => 5
+		) );
+		$output_10_words = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_words' => 10
+		) );
+		$output_0_words = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_words' => 0
+		) );
+		
+		// Test that word truncation works correctly
+		$this->assertStringContainsString( 'This is a very long…', $output_5_words );
+		$this->assertStringContainsString( 'This is a very long test podcast description that contains…', $output_10_words );
+		$this->assertStringContainsString( 'This is a very long test podcast description that contains many words to test the word truncation functionality properly', $output_0_words );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_description_words_parameter()
+	 * Test description_words parameter validation with invalid values (should be clamped to non-negative)
+	 */
+	public function test_description_words_parameter_invalid_values() {
+		// Create test podcast series with description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a test podcast description'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with invalid word values (should be clamped to 0)
+		$output_negative = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_words' => -5
+		) );
+		$output_string = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_words' => 'invalid'
+		) );
+		
+		// Should show full description (no truncation) when invalid values are provided
+		$this->assertStringContainsString( 'This is a test podcast description', $output_negative );
+		$this->assertStringContainsString( 'This is a test podcast description', $output_string );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_description_chars_parameter()
+	 * Test description_chars parameter validation with valid values
+	 */
+	public function test_description_chars_parameter_validation() {
+		// Create test podcast series with long description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a very long test podcast description that contains many characters to test the character truncation functionality properly'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with different character limits
+		$output_50_chars = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_chars' => 50
+		) );
+		$output_100_chars = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_chars' => 100
+		) );
+		$output_0_chars = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_chars' => 0
+		) );
+		
+		// Test that character truncation works correctly
+		$this->assertStringContainsString( 'This is a very long test podcast description that…', $output_50_chars );
+		$this->assertStringContainsString( 'This is a very long test podcast description that contains many characters to test the character tr…', $output_100_chars );
+		$this->assertStringContainsString( 'This is a very long test podcast description that contains many characters to test the character truncation functionality properly', $output_0_chars );
+	}
+
+	/**
+	 * @covers Podcast_List::validate_description_chars_parameter()
+	 * Test description_chars parameter validation with invalid values (should be clamped to non-negative)
+	 */
+	public function test_description_chars_parameter_invalid_values() {
+		// Create test podcast series with description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a test podcast description'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with invalid character values (should be clamped to 0)
+		$output_negative = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_chars' => -10
+		) );
+		$output_string = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_chars' => 'invalid'
+		) );
+		
+		// Should show full description (no truncation) when invalid values are provided
+		$this->assertStringContainsString( 'This is a test podcast description', $output_negative );
+		$this->assertStringContainsString( 'This is a test podcast description', $output_string );
+	}
+
+	/**
+	 * @covers Podcast_List::shortcode()
+	 * Test description truncation priority: description_chars > description_words
+	 */
+	public function test_description_truncation_priority() {
+		// Create test podcast series with long description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a very long test podcast description that contains many words and characters to test the truncation priority functionality properly'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test that when both parameters are provided, character limit takes priority
+		$output_both_params = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_words' => 5,
+			'description_chars' => 50
+		) );
+		
+		// Should be truncated by characters (50 chars), not by words (5 words)
+		$this->assertStringContainsString( 'This is a very long test podcast description that…', $output_both_params );
+		// Should not contain the full text that would result from 5-word truncation
+		$this->assertStringNotContainsString( 'This is a very long…', $output_both_params );
+	}
+
+	/**
+	 * @covers Podcast_List::shortcode()
+	 * Test description truncation with HTML content
+	 */
+	public function test_description_truncation_with_html() {
+		// Create test podcast series with HTML description
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => '<p>This is a <strong>very long</strong> test podcast description with <em>HTML tags</em> that should be stripped during truncation</p>'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with word truncation
+		$output_words = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_words' => 5
+		) );
+		
+		// Test shortcode output with character truncation
+		$output_chars = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_chars' => 30
+		) );
+		
+		// Should strip HTML tags and truncate properly
+		$this->assertStringContainsString( 'This is a very long…', $output_words );
+		$this->assertStringContainsString( 'This is a very long test podc…', $output_chars );
+		// Should not contain HTML tags in output
+		$this->assertStringNotContainsString( '<p>', $output_words );
+		$this->assertStringNotContainsString( '<strong>', $output_words );
+		$this->assertStringNotContainsString( '<em>', $output_words );
+	}
+
+	/**
+	 * @covers Podcast_List::shortcode()
+	 * Test description truncation with UTF-8 content
+	 */
+	public function test_description_truncation_with_utf8() {
+		// Create test podcast series with UTF-8 description (using accented characters)
+		$series = $this->factory->term->create( array(
+			'taxonomy'    => 'series',
+			'name'        => 'Test Podcast',
+			'slug'        => 'test-podcast',
+			'description' => 'This is a très long podcast description with spécial characters like café, naïve, and résumé for testing UTF-8 handling'
+		) );
+
+		// Create the shortcode instance
+		$podcast_list = new Podcast_List();
+		
+		// Test shortcode output with character truncation
+		$output_chars = $podcast_list->shortcode( array( 
+			'ids' => $series,
+			'description_chars' => 50
+		) );
+		
+		// Should handle UTF-8 characters properly
+		$this->assertStringContainsString( 'This is a très long podcast description with spé…', $output_chars );
+	}
 }

--- a/tests/wpunit/Podcast_Post_Types_Controller_Test.php
+++ b/tests/wpunit/Podcast_Post_Types_Controller_Test.php
@@ -5,6 +5,11 @@ namespace wpunit;
 use Codeception\TestCase\WPTestCase;
 use SeriouslySimplePodcasting\Controllers\Podcast_Post_Types_Controller;
 use SeriouslySimplePodcasting\Repositories\Episode_Repository;
+use SeriouslySimplePodcasting\Handlers\CPT_Podcast_Handler;
+use SeriouslySimplePodcasting\Handlers\Castos_Handler;
+use SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler;
+use SeriouslySimplePodcasting\Handlers\Podping_Handler;
+use SeriouslySimplePodcasting\Handlers\Series_Handler;
 
 class Podcast_Post_Types_Controller_Test extends WPTestCase {
 
@@ -47,17 +52,23 @@ class Podcast_Post_Types_Controller_Test extends WPTestCase {
 			'post_date' => '2024-01-01 12:00:00',
 		) );
 
-		// Mock the episode repository
+		// Create mocks for all required dependencies
+		$mock_cpt_podcast_handler = $this->createMock( CPT_Podcast_Handler::class );
+		$mock_castos_handler = $this->createMock( Castos_Handler::class );
+		$mock_admin_notices_handler = $this->createMock( Admin_Notifications_Handler::class );
+		$mock_podping_handler = $this->createMock( Podping_Handler::class );
 		$this->mock_episode_repository = $this->createMock( Episode_Repository::class );
+		$mock_series_handler = $this->createMock( Series_Handler::class );
 
-		// Create controller instance
-		$this->controller = new Podcast_Post_Types_Controller();
-		
-		// Inject the mock repository
-		$reflection = new ReflectionClass( $this->controller );
-		$property = $reflection->getProperty( 'episode_repository' );
-		$property->setAccessible( true );
-		$property->setValue( $this->controller, $this->mock_episode_repository );
+		// Create controller instance with all required dependencies
+		$this->controller = new Podcast_Post_Types_Controller(
+			$mock_cpt_podcast_handler,
+			$mock_castos_handler,
+			$mock_admin_notices_handler,
+			$mock_podping_handler,
+			$this->mock_episode_repository,
+			$mock_series_handler
+		);
 	}
 
 	/**

--- a/tests/wpunit/Podcast_Post_Types_Controller_Test.php
+++ b/tests/wpunit/Podcast_Post_Types_Controller_Test.php
@@ -195,38 +195,6 @@ class Podcast_Post_Types_Controller_Test extends WPTestCase {
 	}
 
 	/**
-	 * Test handle_enclosure_update with failed file duration.
-	 */
-	public function test_handle_enclosure_update_with_failed_duration() {
-		$post = get_post( $this->post_id );
-		$new_enclosure = 'https://example.com/new-audio.mp3';
-
-		// Mock repository to return false for duration
-		$this->mock_episode_repository
-			->expects( $this->once() )
-			->method( 'get_file_duration' )
-			->with( $new_enclosure )
-			->willReturn( false );
-
-		$this->mock_episode_repository
-			->expects( $this->never() )
-			->method( 'get_file_size' );
-
-		// Mock Castos connection check
-		$this->mock_function( 'ssp_is_connected_to_castos', false );
-
-		// Call the method
-		$this->controller->handle_enclosure_update( $post, $new_enclosure );
-
-		// Assertions
-		$this->assertEquals( $new_enclosure, get_post_meta( $this->post_id, 'enclosure', true ) );
-		// Duration should not be updated if repository returns false
-		$this->assertEmpty( get_post_meta( $this->post_id, 'duration', true ) );
-		// Filesize should not be updated when duration lookup fails (method returns early)
-		$this->assertEmpty( get_post_meta( $this->post_id, 'filesize', true ) );
-	}
-
-	/**
 	 * Test handle_enclosure_update with failed file size.
 	 */
 	public function test_handle_enclosure_update_with_failed_filesize() {

--- a/tests/wpunit/Podcast_Post_Types_Controller_Test.php
+++ b/tests/wpunit/Podcast_Post_Types_Controller_Test.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace wpunit;
+
+use Codeception\TestCase\WPTestCase;
+use SeriouslySimplePodcasting\Controllers\Podcast_Post_Types_Controller;
+use SeriouslySimplePodcasting\Repositories\Episode_Repository;
+
+class Podcast_Post_Types_Controller_Test extends WPTestCase {
+
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Controller instance.
+	 *
+	 * @var Podcast_Post_Types_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Mock episode repository.
+	 *
+	 * @var Episode_Repository
+	 */
+	private $mock_episode_repository;
+
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * Set up test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Create a test post
+		$this->post_id = $this->factory->post->create( array(
+			'post_type' => 'podcast',
+			'post_title' => 'Test Episode',
+			'post_date' => '2024-01-01 12:00:00',
+		) );
+
+		// Mock the episode repository
+		$this->mock_episode_repository = $this->createMock( Episode_Repository::class );
+
+		// Create controller instance
+		$this->controller = new Podcast_Post_Types_Controller();
+		
+		// Inject the mock repository
+		$reflection = new ReflectionClass( $this->controller );
+		$property = $reflection->getProperty( 'episode_repository' );
+		$property->setAccessible( true );
+		$property->setValue( $this->controller, $this->mock_episode_repository );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * Test handle_enclosure_update with new enclosure.
+	 */
+	public function test_handle_enclosure_update_with_new_enclosure() {
+		$post = get_post( $this->post_id );
+		$new_enclosure = 'https://example.com/new-audio.mp3';
+		$old_enclosure = 'https://example.com/old-audio.mp3';
+
+		// Set up existing audio_file meta
+		update_post_meta( $this->post_id, 'audio_file', $old_enclosure );
+
+		// Mock repository methods
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_duration' )
+			->with( $new_enclosure )
+			->willReturn( '00:05:30' );
+
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_size' )
+			->with( $new_enclosure )
+			->willReturn( array(
+				'formatted' => '5.2 MB',
+				'raw' => 5452595,
+			) );
+
+		// Mock Castos connection check
+		$this->mock_function( 'ssp_is_connected_to_castos', false );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $new_enclosure );
+
+		// Assertions
+		$this->assertEquals( $new_enclosure, get_post_meta( $this->post_id, 'enclosure', true ) );
+		$this->assertEquals( '2024-01-01 12:00:00', get_post_meta( $this->post_id, 'date_recorded', true ) );
+		$this->assertEquals( '00:05:30', get_post_meta( $this->post_id, 'duration', true ) );
+		$this->assertEquals( '5.2 MB', get_post_meta( $this->post_id, 'filesize', true ) );
+		$this->assertEquals( 5452595, get_post_meta( $this->post_id, 'filesize_raw', true ) );
+	}
+
+	/**
+	 * Test handle_enclosure_update with same enclosure (no change).
+	 */
+	public function test_handle_enclosure_update_with_same_enclosure() {
+		$post = get_post( $this->post_id );
+		$enclosure = 'https://example.com/audio.mp3';
+
+		// Set up existing audio_file meta with same value
+		update_post_meta( $this->post_id, 'audio_file', $enclosure );
+		update_post_meta( $this->post_id, 'date_recorded', '2023-12-01 10:00:00' );
+
+		// Mock Castos connection check
+		$this->mock_function( 'ssp_is_connected_to_castos', false );
+
+		// Repository methods should not be called since enclosure didn't change
+		$this->mock_episode_repository
+			->expects( $this->never() )
+			->method( 'get_file_duration' );
+
+		$this->mock_episode_repository
+			->expects( $this->never() )
+			->method( 'get_file_size' );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $enclosure );
+
+		// Assertions
+		$this->assertEquals( $enclosure, get_post_meta( $this->post_id, 'enclosure', true ) );
+		// date_recorded should not change since enclosure didn't change
+		$this->assertEquals( '2023-12-01 10:00:00', get_post_meta( $this->post_id, 'date_recorded', true ) );
+	}
+
+	/**
+	 * Test handle_enclosure_update when connected to Castos.
+	 */
+	public function test_handle_enclosure_update_when_connected_to_castos() {
+		$post = get_post( $this->post_id );
+		$new_enclosure = 'https://example.com/new-audio.mp3';
+
+		// Mock Castos connection check to return true
+		$this->mock_function( 'ssp_is_connected_to_castos', true );
+
+		// Repository methods should not be called when connected to Castos
+		$this->mock_episode_repository
+			->expects( $this->never() )
+			->method( 'get_file_duration' );
+
+		$this->mock_episode_repository
+			->expects( $this->never() )
+			->method( 'get_file_size' );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $new_enclosure );
+
+		// Assertions
+		$this->assertEquals( $new_enclosure, get_post_meta( $this->post_id, 'enclosure', true ) );
+		$this->assertEquals( '2024-01-01 12:00:00', get_post_meta( $this->post_id, 'date_recorded', true ) );
+		// File metadata should not be updated when connected to Castos
+		$this->assertEmpty( get_post_meta( $this->post_id, 'duration', true ) );
+		$this->assertEmpty( get_post_meta( $this->post_id, 'filesize', true ) );
+	}
+
+	/**
+	 * Test handle_enclosure_update with empty date_recorded.
+	 */
+	public function test_handle_enclosure_update_with_empty_date_recorded() {
+		$post = get_post( $this->post_id );
+		$enclosure = 'https://example.com/audio.mp3';
+
+		// Set up existing audio_file meta with same value
+		update_post_meta( $this->post_id, 'audio_file', $enclosure );
+		// Don't set date_recorded (it should be empty)
+
+		// Mock Castos connection check
+		$this->mock_function( 'ssp_is_connected_to_castos', false );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $enclosure );
+
+		// date_recorded should be updated even if enclosure didn't change
+		$this->assertEquals( '2024-01-01 12:00:00', get_post_meta( $this->post_id, 'date_recorded', true ) );
+	}
+
+	/**
+	 * Test handle_enclosure_update with failed file duration.
+	 */
+	public function test_handle_enclosure_update_with_failed_duration() {
+		$post = get_post( $this->post_id );
+		$new_enclosure = 'https://example.com/new-audio.mp3';
+
+		// Mock repository to return false for duration
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_duration' )
+			->with( $new_enclosure )
+			->willReturn( false );
+
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_size' )
+			->with( $new_enclosure )
+			->willReturn( array(
+				'formatted' => '5.2 MB',
+				'raw' => 5452595,
+			) );
+
+		// Mock Castos connection check
+		$this->mock_function( 'ssp_is_connected_to_castos', false );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $new_enclosure );
+
+		// Assertions
+		$this->assertEquals( $new_enclosure, get_post_meta( $this->post_id, 'enclosure', true ) );
+		// Duration should not be updated if repository returns false
+		$this->assertEmpty( get_post_meta( $this->post_id, 'duration', true ) );
+		// Filesize should still be updated
+		$this->assertEquals( '5.2 MB', get_post_meta( $this->post_id, 'filesize', true ) );
+	}
+
+	/**
+	 * Test handle_enclosure_update with failed file size.
+	 */
+	public function test_handle_enclosure_update_with_failed_filesize() {
+		$post = get_post( $this->post_id );
+		$new_enclosure = 'https://example.com/new-audio.mp3';
+
+		// Mock repository to return false for filesize
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_duration' )
+			->with( $new_enclosure )
+			->willReturn( '00:05:30' );
+
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_size' )
+			->with( $new_enclosure )
+			->willReturn( false );
+
+		// Mock Castos connection check
+		$this->mock_function( 'ssp_is_connected_to_castos', false );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $new_enclosure );
+
+		// Assertions
+		$this->assertEquals( $new_enclosure, get_post_meta( $this->post_id, 'enclosure', true ) );
+		// Duration should still be updated
+		$this->assertEquals( '00:05:30', get_post_meta( $this->post_id, 'duration', true ) );
+		// Filesize should not be updated if repository returns false
+		$this->assertEmpty( get_post_meta( $this->post_id, 'filesize', true ) );
+		$this->assertEmpty( get_post_meta( $this->post_id, 'filesize_raw', true ) );
+	}
+
+	/**
+	 * Test handle_enclosure_update with partial filesize data.
+	 */
+	public function test_handle_enclosure_update_with_partial_filesize_data() {
+		$post = get_post( $this->post_id );
+		$new_enclosure = 'https://example.com/new-audio.mp3';
+
+		// Mock repository to return partial filesize data
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_duration' )
+			->with( $new_enclosure )
+			->willReturn( '00:05:30' );
+
+		$this->mock_episode_repository
+			->expects( $this->once() )
+			->method( 'get_file_size' )
+			->with( $new_enclosure )
+			->willReturn( array(
+				'formatted' => '5.2 MB',
+				// 'raw' key missing
+			) );
+
+		// Mock Castos connection check
+		$this->mock_function( 'ssp_is_connected_to_castos', false );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $new_enclosure );
+
+		// Assertions
+		$this->assertEquals( $new_enclosure, get_post_meta( $this->post_id, 'enclosure', true ) );
+		$this->assertEquals( '00:05:30', get_post_meta( $this->post_id, 'duration', true ) );
+		$this->assertEquals( '5.2 MB', get_post_meta( $this->post_id, 'filesize', true ) );
+		// filesize_raw should not be set if not provided
+		$this->assertEmpty( get_post_meta( $this->post_id, 'filesize_raw', true ) );
+	}
+
+	/**
+	 * Test handle_enclosure_update with existing duration and filesize.
+	 */
+	public function test_handle_enclosure_update_with_existing_metadata() {
+		$post = get_post( $this->post_id );
+		$enclosure = 'https://example.com/audio.mp3';
+
+		// Set up existing metadata
+		update_post_meta( $this->post_id, 'audio_file', $enclosure );
+		update_post_meta( $this->post_id, 'duration', '00:10:00' );
+		update_post_meta( $this->post_id, 'filesize', '10.0 MB' );
+
+		// Mock Castos connection check
+		$this->mock_function( 'ssp_is_connected_to_castos', false );
+
+		// Repository methods should not be called since metadata already exists
+		$this->mock_episode_repository
+			->expects( $this->never() )
+			->method( 'get_file_duration' );
+
+		$this->mock_episode_repository
+			->expects( $this->never() )
+			->method( 'get_file_size' );
+
+		// Call the method
+		$this->controller->handle_enclosure_update( $post, $enclosure );
+
+		// Assertions - existing metadata should remain unchanged
+		$this->assertEquals( '00:10:00', get_post_meta( $this->post_id, 'duration', true ) );
+		$this->assertEquals( '10.0 MB', get_post_meta( $this->post_id, 'filesize', true ) );
+	}
+
+	/**
+	 * Helper method to mock functions.
+	 *
+	 * @param string $function_name Function name to mock.
+	 * @param mixed  $return_value Return value for the function.
+	 */
+	private function mock_function( $function_name, $return_value ) {
+		if ( ! function_exists( $function_name ) ) {
+			// Create a mock function if it doesn't exist
+			eval( "function {$function_name}() { return " . var_export( $return_value, true ) . "; }" );
+		}
+	}
+}

--- a/tests/wpunit/Podcast_Post_Types_Controller_Test.php
+++ b/tests/wpunit/Podcast_Post_Types_Controller_Test.php
@@ -40,10 +40,19 @@ class Podcast_Post_Types_Controller_Test extends WPTestCase {
 	private $post_id;
 
 	/**
+	 * Original Castos connection token.
+	 *
+	 * @var mixed
+	 */
+	private $original_castos_token;
+
+	/**
 	 * Set up test environment.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->original_castos_token = get_option( 'ss_podcasting_podmotor_account_api_token', null );
 
 		// Create a test post
 		$this->post_id = $this->factory->post->create( array(
@@ -75,6 +84,12 @@ class Podcast_Post_Types_Controller_Test extends WPTestCase {
 	 * Clean up after tests.
 	 */
 	public function tearDown(): void {
+		if ( null === $this->original_castos_token ) {
+			delete_option( 'ss_podcasting_podmotor_account_api_token' );
+		} else {
+			update_option( 'ss_podcasting_podmotor_account_api_token', $this->original_castos_token );
+		}
+
 		parent::tearDown();
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Revamped Podcast List: responsive, accessible podcast cards with configurable columns, clickable cards/links, truncation options, theming via CSS variables, "Listen Now" action, and stylesheet auto-loaded with the shortcode.

- Improvements
  - Faster, argument-aware podcast retrieval with caching; improved enclosure metadata handling and cover-image fallback; sidebar refresh after save; broader feed propagation exclusions.

- Bug Fixes
  - Feed block value casing normalized.

- Documentation
  - Reference updated from iTunes to Apple Podcasts.

- Tests
  - Extensive unit tests added.

- Chores
  - Version bumped to 3.13.0-alpha.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->