### PR TITLE
Version 3.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seriously-simple-podcasting",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "main": "build/index.js",
   "author": "CastosHQ",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,14 @@ You can find complete user and developer documentation (along with the FAQs) on 
 
 == Changelog ==
 
+= 3.13.0 =
+2025-10-06
+[NEW] Podcast list shortcode with sorting, colors, and other options.
+[NEW] Series-level "Mark to be Removed" setting to block podcasts from appearing in directories.
+[UPDATE] Custom episode GUID support, preserve original episode identifiers when importing RSS feeds.
+[UPDATE] Automatic permalink refresh on plugin updates to ensure proper feed URLs.
+[FIX] Fixed episode file missing message to update automatically when files are added or removed.
+
 = 3.12.0 =
 2025-08-27
 [FIX] Fixed Castos explicit sync functionality.

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.13.0-alpha.3
+ * Version: 3.13.0
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.13.0-alpha.3' );
+define( 'SSP_VERSION', '3.13.0' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
= 3.13.0 =
2025-10-06
[NEW] Added customizable podcast list shortcode with sorting, colors, clickable titles, and description display options.
[NEW] Added series-level "Mark to be Removed" setting that adds iTunes block tags to prevent podcast series from appearing in directories.
[NEW] Custom episode GUID support, preserve original episode identifiers when importing RSS feeds.
[UPDATE] Fixed episode file missing message to update automatically when files are added or removed.
[UPDATE] Automatic permalink refresh on plugin updates to ensure proper feed URLs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable podcast list shortcode with sorting, color options, clickable titles, and optional descriptions.
  * Series-level “Mark to be Removed” setting to block a series from podcast directories.
  * Support for custom episode GUIDs when importing RSS feeds.
* **Bug Fixes**
  * Episode file-missing message now updates automatically when files change.
* **Chores**
  * Automatically refresh permalinks on plugin update to ensure correct feed URLs.
  * Release version 3.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->