### PR TITLE
Version 3.15.0

### DIFF
--- a/php/classes/controllers/class-app-controller.php
+++ b/php/classes/controllers/class-app-controller.php
@@ -25,6 +25,7 @@ use SeriouslySimplePodcasting\Handlers\Settings_Handler;
 use SeriouslySimplePodcasting\Handlers\Upgrade_Handler;
 use SeriouslySimplePodcasting\Helpers\Log_Helper;
 use SeriouslySimplePodcasting\Integrations\Blocks\Castos_Blocks;
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
 use SeriouslySimplePodcasting\Integrations\Elementor\Elementor_Widgets;
 use SeriouslySimplePodcasting\Integrations\LifterLMS\LifterLMS_Integrator;
 use SeriouslySimplePodcasting\Integrations\Memberpress\Memberpress_Integrator;
@@ -434,7 +435,8 @@ class App_Controller {
 		 * Only load Blocks if the WordPress version is newer than 5.0.
 		 */
 		if ( version_compare( $this->get_wp_version(), '5.0', '>=' ) ) {
-			new Castos_Blocks( $this->admin_notices_handler, $this->episode_repository, $this->players_controller, $this->renderer );
+			$episode_list_renderer = new Episode_List_Presenter( $this->episode_repository, $this->players_controller, $this->renderer );
+			new Castos_Blocks( $this->admin_notices_handler, $episode_list_renderer );
 		}
 
 		// Elementor integration.

--- a/php/classes/controllers/class-app-controller.php
+++ b/php/classes/controllers/class-app-controller.php
@@ -86,6 +86,13 @@ class App_Controller {
 	protected $cron_controller;
 
 	/**
+	 * Episode list presenter instance.
+	 *
+	 * @var Episode_List_Presenter
+	 */
+	protected $episode_list_presenter;
+
+	/**
 	 * Shortcodes controller instance.
 	 *
 	 * @var Shortcodes_Controller
@@ -364,8 +371,6 @@ class App_Controller {
 
 		$this->db_migration_controller = DB_Migration_Controller::instance()->init( $this->admin_notices_handler );
 
-		$this->shortcodes_controller = new Shortcodes_Controller( $this->file, $this->version );
-
 		$this->widgets_controller = new Widgets_Controller( $this->file, $this->version );
 
 		$this->ajax_handler = new Ajax_Handler( $this->castos_handler, $this->admin_notices_handler );
@@ -402,6 +407,8 @@ class App_Controller {
 
 		$this->admin_controller              = new Admin_Controller( $this->renderer, $this->castos_handler );
 		$this->players_controller            = new Players_Controller( $this->renderer, $this->options_handler, $this->episode_repository );
+		$this->episode_list_presenter        = new Episode_List_Presenter( $this->episode_repository, $this->players_controller, $this->renderer );
+		$this->shortcodes_controller         = new Shortcodes_Controller( $this->file, $this->version, $this->episode_list_presenter );
 		$this->podcast_post_types_controller = new Podcast_Post_Types_Controller(
 			$this->cpt_podcast_handler,
 			$this->castos_handler,
@@ -435,8 +442,7 @@ class App_Controller {
 		 * Only load Blocks if the WordPress version is newer than 5.0.
 		 */
 		if ( version_compare( $this->get_wp_version(), '5.0', '>=' ) ) {
-			$episode_list_renderer = new Episode_List_Presenter( $this->episode_repository, $this->players_controller, $this->renderer );
-			new Castos_Blocks( $this->admin_notices_handler, $episode_list_renderer );
+			new Castos_Blocks( $this->admin_notices_handler, $this->episode_list_presenter );
 		}
 
 		// Elementor integration.

--- a/php/classes/controllers/class-app-controller.php
+++ b/php/classes/controllers/class-app-controller.php
@@ -12,6 +12,7 @@ namespace SeriouslySimplePodcasting\Controllers;
 
 use SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler;
 use SeriouslySimplePodcasting\Handlers\Ajax_Handler;
+use SeriouslySimplePodcasting\Handlers\Archive_Page_Handler;
 use SeriouslySimplePodcasting\Handlers\Castos_Handler;
 use SeriouslySimplePodcasting\Handlers\CPT_Podcast_Handler;
 use SeriouslySimplePodcasting\Handlers\Feed_Handler;
@@ -206,6 +207,13 @@ class App_Controller {
 	protected $cpt_podcast_handler;
 
 	/**
+	 * Archive page handler instance.
+	 *
+	 * @var Archive_Page_Handler
+	 */
+	protected $archive_page_handler;
+
+	/**
 	 * Roles handler instance.
 	 *
 	 * @var Roles_Handler
@@ -341,17 +349,19 @@ class App_Controller {
 
 		$this->episode_repository = new Episode_Repository( $this->feed_handler );
 
-		$this->admin_notices_handler = new Admin_Notifications_Handler();
+		$this->roles_handler = new Roles_Handler();
+
+		$this->cpt_podcast_handler = new CPT_Podcast_Handler( $this->roles_handler, $this->feed_handler );
+
+		$this->archive_page_handler = new Archive_Page_Handler();
+
+		$this->admin_notices_handler = new Admin_Notifications_Handler( $this->archive_page_handler, $this->renderer );
 
 		$this->castos_handler = new Castos_Handler( $this->feed_handler, $this->logger, $this->admin_notices_handler );
 
 		$this->onboarding_controller = new Onboarding_Controller( $this->renderer, $this->settings_handler );
 
 		$this->db_migration_controller = DB_Migration_Controller::instance()->init( $this->admin_notices_handler );
-
-		$this->roles_handler = new Roles_Handler();
-
-		$this->cpt_podcast_handler = new CPT_Podcast_Handler( $this->roles_handler, $this->feed_handler );
 
 		$this->shortcodes_controller = new Shortcodes_Controller( $this->file, $this->version );
 
@@ -408,7 +418,7 @@ class App_Controller {
 
 		// todo: further refactoring - get rid of global here.
 		global $ss_podcasting;
-		$ss_podcasting = new Frontend_Controller( $this->players_controller, $this->episode_repository );
+		$ss_podcasting = new Frontend_Controller( $this->players_controller, $this->episode_repository, $this->archive_page_handler );
 
 		$this->init_integrations();
 		$this->init_rest_api();
@@ -749,6 +759,11 @@ class App_Controller {
 	 * @return void
 	 */
 	public function activate() {
+		// On fresh install, create the podcast archive page.
+		if ( false === get_option( 'ssp_version' ) ) {
+			$this->archive_page_handler->create_podcast_archive_page();
+		}
+
 		// Setup all custom URL rules
 		$this->podcast_post_types_controller->register_post_type();
 		$this->series_controller->register_taxonomy();

--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -3,6 +3,7 @@
 namespace SeriouslySimplePodcasting\Controllers;
 
 use SeriouslySimplePodcasting\Entities\Castos_File_Data;
+use SeriouslySimplePodcasting\Handlers\Archive_Page_Handler;
 use SeriouslySimplePodcasting\Repositories\Episode_Repository;
 use SeriouslySimplePodcasting\Traits\Logger;
 use SeriouslySimplePodcasting\Traits\Useful_Variables;
@@ -39,6 +40,11 @@ class Frontend_Controller {
 	public $episode_repository;
 
 	/**
+	 * @var Archive_Page_Handler
+	 */
+	protected $archive_page_handler;
+
+	/**
 	 * @var array
 	 * */
 	protected $removed_filters;
@@ -66,14 +72,16 @@ class Frontend_Controller {
 	/**
 	 * Frontend_Controller constructor.
 	 *
-	 * @param Players_Controller $players_controller
-	 * @param Episode_Repository $episode_repository
+	 * @param Players_Controller  $players_controller
+	 * @param Episode_Repository  $episode_repository
+	 * @param Archive_Page_Handler $archive_page_handler
 	 */
-	public function __construct( $players_controller, $episode_repository ) {
+	public function __construct( $players_controller, $episode_repository, $archive_page_handler ) {
 		$this->init_useful_variables();
 
-		$this->players_controller = $players_controller;
-		$this->episode_repository = $episode_repository;
+		$this->players_controller   = $players_controller;
+		$this->episode_repository   = $episode_repository;
+		$this->archive_page_handler = $archive_page_handler;
 
 		$this->register_hooks_and_filters();
 		$this->register_ajax_actions();
@@ -123,6 +131,15 @@ class Frontend_Controller {
 		add_action( 'wp', array( $this, 'download_file' ), 1 );
 
 		add_filter( 'feed_content_type', array( $this, 'feed_content_type' ), 10, 2 );
+
+		// When a podcast archive page is assigned, serve the page instead of the CPT archive template.
+		add_filter( 'template_include', array( $this, 'maybe_serve_archive_page' ), 99 );
+
+		// Redirect the archive page's own URL to the podcast archive URL.
+		add_action( 'template_redirect', array( $this, 'redirect_archive_page_to_podcast_url' ) );
+
+		// Flush rewrite rules when the podcast archive page setting changes.
+		add_action( 'update_option_' . Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, 'flush_rewrite_rules' );
 
 		// Handle localisation
 		add_action( 'plugins_loaded', array( $this, 'load_localisation' ) );
@@ -627,6 +644,24 @@ class Frontend_Controller {
 				$query->set( 'post_type', $podcast_post_types );
 			}
 		}
+	}
+
+	/**
+	 * @see Archive_Page_Handler::serve_archive_page()
+	 */
+	public function maybe_serve_archive_page( $template ) {
+		if ( ! is_post_type_archive( SSP_CPT_PODCAST ) ) {
+			return $template;
+		}
+
+		return $this->archive_page_handler->serve_archive_page( $template );
+	}
+
+	/**
+	 * @see Archive_Page_Handler::redirect_archive_page_to_podcast_url()
+	 */
+	public function redirect_archive_page_to_podcast_url() {
+		$this->archive_page_handler->redirect_archive_page_to_podcast_url();
 	}
 
 	public function add_all_post_types_for_tag_archive( $query ) {

--- a/php/classes/controllers/class-shortcodes-controller.php
+++ b/php/classes/controllers/class-shortcodes-controller.php
@@ -12,6 +12,8 @@ use SeriouslySimplePodcasting\ShortCodes\Podcast;
 use SeriouslySimplePodcasting\ShortCodes\Podcast_Episode;
 use SeriouslySimplePodcasting\ShortCodes\Podcast_Playlist;
 use SeriouslySimplePodcasting\ShortCodes\Podcast_List;
+use SeriouslySimplePodcasting\ShortCodes\Episode_List;
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,13 +31,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Shortcodes_Controller extends Controller {
 
 	/**
+	 * @var Episode_List_Presenter
+	 */
+	private $episode_list_presenter;
+
+	/**
 	 * Constructor
 	 *
-	 * @param string $file Plugin base file.
-	 * @param string $version Plugin version number.
+	 * @param string                 $file                   Plugin base file.
+	 * @param string                 $version                Plugin version number.
+	 * @param Episode_List_Presenter $episode_list_presenter Episode list presenter instance.
 	 */
-	public function __construct( $file, $version ) {
+	public function __construct( $file, $version, $episode_list_presenter ) {
 		parent::__construct( $file, $version );
+
+		$this->episode_list_presenter = $episode_list_presenter;
 
 		$this->register_hooks_and_filters();
 	}
@@ -59,5 +69,6 @@ class Shortcodes_Controller extends Controller {
 		add_shortcode( 'podcast_episode', array( new Podcast_Episode(), 'shortcode' ) );
 		add_shortcode( 'podcast_playlist', array( new Podcast_Playlist(), 'shortcode' ) );
 		add_shortcode( 'ssp_podcasts', array( new Podcast_List(), 'shortcode' ) );
+		add_shortcode( 'ssp_episode_list', array( new Episode_List( $this->episode_list_presenter ), 'shortcode' ) );
 	}
 }

--- a/php/classes/handlers/class-admin-notifications-handler.php
+++ b/php/classes/handlers/class-admin-notifications-handler.php
@@ -11,6 +11,7 @@
 namespace SeriouslySimplePodcasting\Handlers;
 
 use SeriouslySimplePodcasting\Interfaces\Service;
+use SeriouslySimplePodcasting\Renderers\Renderer;
 use SeriouslySimplePodcasting\Traits\URL_Helper;
 use SeriouslySimplePodcasting\Traits\Useful_Variables;
 
@@ -66,13 +67,27 @@ class Admin_Notifications_Handler implements Service {
 	const ERROR   = 'error';
 	const SUCCESS = 'success';
 
+	/**
+	 * @var Archive_Page_Handler
+	 */
+	protected $archive_page_handler;
+
+	/**
+	 * @var Renderer
+	 */
+	protected $renderer;
 
 	/**
 	 * Admin_Notifications_Handler constructor.
 	 *
+	 * @param Archive_Page_Handler $archive_page_handler
+	 * @param Renderer             $renderer
+	 *
 	 * @return void
 	 */
-	public function __construct() {
+	public function __construct( $archive_page_handler, $renderer ) {
+		$this->archive_page_handler = $archive_page_handler;
+		$this->renderer             = $renderer;
 		$this->init_useful_variables();
 
 		return $this;
@@ -97,6 +112,11 @@ class Admin_Notifications_Handler implements Service {
 
 		// Print flash notices
 		add_action( 'admin_notices', array( $this, 'display_notices' ), 12 );
+
+		// Archive page upgrade notice for existing installs.
+		add_action( 'admin_notices', array( $this, 'maybe_show_archive_page_notice' ), 12 );
+
+		add_action( 'admin_init', array( $this, 'handle_archive_page_notice_action' ) );
 
 		return $this;
 	}
@@ -609,5 +629,77 @@ class Admin_Notifications_Handler implements Service {
 		);
 
 		return apply_filters( 'ssp_predefined_notices', $notices );
+	}
+
+	/**
+	 * Shows the archive page upgrade notice for existing installs.
+	 *
+	 * @return void
+	 * @since 3.15.0
+	 */
+	public function maybe_show_archive_page_notice() {
+		if ( ! $this->is_ssp_post_page() && ! $this->is_ssp_admin_page() ) {
+			return;
+		}
+
+		if ( ! $this->archive_page_handler->should_show_archive_page_notice() ) {
+			return;
+		}
+
+		$this->render_archive_page_notice();
+	}
+
+	/**
+	 * Renders the archive page upgrade notice HTML.
+	 *
+	 * @return void
+	 * @since 3.15.0
+	 */
+	protected function render_archive_page_notice() {
+		$this->renderer->render( 'archive-page-notice', array(
+			'setup_url'   => wp_nonce_url(
+				add_query_arg( 'ssp_archive_page_action', 'setup', admin_url( 'admin.php' ) ),
+				'ssp_archive_page_action'
+			),
+			'dismiss_url' => wp_nonce_url(
+				add_query_arg( 'ssp_archive_page_action', 'dismiss', admin_url( 'admin.php' ) ),
+				'ssp_archive_page_action'
+			),
+			'archive_url' => get_post_type_archive_link( SSP_CPT_PODCAST ),
+		) );
+	}
+
+	/**
+	 * Dispatches archive page notice actions to the handler.
+	 *
+	 * @return void
+	 * @since 3.15.0
+	 */
+	public function handle_archive_page_notice_action() {
+		if ( empty( $_GET['ssp_archive_page_action'] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$action = sanitize_text_field( $_GET['ssp_archive_page_action'] );
+
+		if ( ! in_array( $action, array( 'setup', 'dismiss' ), true ) ) {
+			return;
+		}
+
+		check_admin_referer( 'ssp_archive_page_action' );
+
+		if ( 'setup' === $action ) {
+			$result = $this->archive_page_handler->handle_setup_action();
+			$this->add_flash_notice( $result['message'], $result['success'] ? self::SUCCESS : self::ERROR );
+		} else {
+			$result = $this->archive_page_handler->handle_dismiss_action();
+		}
+
+		wp_safe_redirect( $result['redirect'] );
+		exit;
 	}
 }

--- a/php/classes/handlers/class-archive-page-handler.php
+++ b/php/classes/handlers/class-archive-page-handler.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace SeriouslySimplePodcasting\Handlers;
+
+use SeriouslySimplePodcasting\Interfaces\Service;
+
+/**
+ * Manages archive page lifecycle — creation, lookup, routing, and redirects.
+ *
+ * @package Seriously Simple Podcasting
+ * @since 3.15.0
+ */
+class Archive_Page_Handler implements Service {
+
+	/**
+	 * Option name for the podcast archive page ID.
+	 */
+	const OPTION_PODCAST_PAGE_ID = 'ss_podcasting_podcast_page_id';
+
+	/**
+	 * Default slug for the podcast archive page.
+	 */
+	const PODCAST_ARCHIVE_SLUG = 'ssp-podcast-archive';
+
+	/**
+	 * Option name for the archive page notice dismissed flag.
+	 */
+	const OPTION_NOTICE_DISMISSED = 'ssp_podcast_page_notice_dismissed';
+
+	/**
+	 * Returns the podcast archive page ID, or 0 if not set.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return int
+	 */
+	public function get_podcast_page_id() {
+		return (int) get_option( self::OPTION_PODCAST_PAGE_ID );
+	}
+
+	/**
+	 * Checks whether the podcast archive page is assigned and published.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return bool
+	 */
+	public function is_podcast_page_assigned() {
+		return $this->is_page_assigned( self::OPTION_PODCAST_PAGE_ID );
+	}
+
+	/**
+	 * Checks whether the option points to a valid published page.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param string $page_id_option Option name that stores the page ID.
+	 *
+	 * @return bool
+	 */
+	public function is_page_assigned( $page_id_option ) {
+		$page_id = (int) get_option( $page_id_option );
+
+		if ( ! $page_id ) {
+			return false;
+		}
+
+		$page = get_post( $page_id );
+
+		return $page && 'page' === $page->post_type && 'publish' === $page->post_status;
+	}
+
+	/**
+	 * Finds an existing page by slug, including trashed pages.
+	 *
+	 * Pure lookup — does not modify the page or any options.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param string $slug Page slug to search for.
+	 *
+	 * @return int Page ID, or 0 if not found.
+	 */
+	public function find_page( $slug ) {
+		$page = get_page_by_path( $slug, OBJECT, 'page' );
+
+		// Search for trashed page (WordPress appends __trashed to slug).
+		if ( ! $page ) {
+			$page = get_page_by_path( $slug . '__trashed', OBJECT, 'page' );
+		}
+
+		return $page ? (int) $page->ID : 0;
+	}
+
+	/**
+	 * Creates a new WordPress page and stores its ID in the given option.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param string $page_id_option Option name to store the page ID.
+	 * @param string $slug          Page slug.
+	 * @param string $page_title    Page title.
+	 * @param string $page_content  Page content (block markup).
+	 *
+	 * @return int Page ID, or 0 on failure.
+	 */
+	public function create_page( $page_id_option, $slug, $page_title, $page_content ) {
+		$page_id = wp_insert_post( array(
+			'post_status'    => 'publish',
+			'post_type'      => 'page',
+			'post_author'    => get_current_user_id() ?: 1,
+			'post_name'      => $slug,
+			'post_title'     => $page_title,
+			'post_content'   => $page_content,
+			'comment_status' => 'closed',
+		) );
+
+		if ( ! $page_id || is_wp_error( $page_id ) ) {
+			return 0;
+		}
+
+		update_option( $page_id_option, (int) $page_id );
+
+		return (int) $page_id;
+	}
+
+	/**
+	 * Replaces the main query with the assigned archive page.
+	 *
+	 * Caller is responsible for checking that we're on the correct archive.
+	 * Returns the original template if no page is assigned or published.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param string $template The path of the template to include.
+	 *
+	 * @return string
+	 */
+	public function serve_archive_page( $template ) {
+		$page_id = $this->get_podcast_page_id();
+
+		if ( ! $page_id ) {
+			return $template;
+		}
+
+		$page = get_post( $page_id );
+
+		if ( ! $page || 'page' !== $page->post_type || 'publish' !== $page->post_status ) {
+			return $template;
+		}
+
+		// Replace the main query with the page.
+		global $wp_query;
+
+		$wp_query->posts             = array( $page );
+		$wp_query->post_count        = 1;
+		$wp_query->found_posts       = 1;
+		$wp_query->max_num_pages     = 1;
+		$wp_query->post              = $page;
+		$wp_query->queried_object    = $page;
+		$wp_query->queried_object_id = $page_id;
+
+		$wp_query->is_page              = true;
+		$wp_query->is_singular          = true;
+		$wp_query->is_archive           = false;
+		$wp_query->is_post_type_archive = false;
+
+		$wp_query->rewind_posts();
+
+		// Resolve the page template.
+		$page_template_slug = get_page_template_slug( $page_id );
+
+		if ( $page_template_slug ) {
+			$resolved = locate_template( $page_template_slug );
+
+			if ( $resolved ) {
+				return $resolved;
+			}
+		}
+
+		return locate_template( array( 'page.php', 'singular.php', 'index.php' ) ) ?: $template;
+	}
+
+	/**
+	 * Redirects the archive page's own URL to the podcast archive URL.
+	 *
+	 * The archive page uses a non-public slug (e.g. "ssp-podcast-archive") to avoid
+	 * conflicts with the CPT archive rewrite rules. If someone visits the page directly,
+	 * redirect them to the canonical /podcast/ URL.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return void
+	 */
+	public function redirect_archive_page_to_podcast_url() {
+		$page_id = $this->get_podcast_page_id();
+
+		if ( ! $page_id || ! is_page( $page_id ) ) {
+			return;
+		}
+
+		$archive_url = get_post_type_archive_link( SSP_CPT_PODCAST );
+
+		if ( $archive_url ) {
+			wp_safe_redirect( $archive_url, 302 );
+			exit;
+		}
+	}
+
+	/**
+	 * Returns the default block content for the podcast archive page.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return string
+	 */
+	protected function get_podcast_archive_page_content() {
+		return '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->';
+	}
+
+	/**
+	 * Finds or creates the podcast archive page.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return int Page ID, or 0 on failure.
+	 */
+	public function create_podcast_archive_page() {
+		if ( $this->is_podcast_page_assigned() ) {
+			return $this->get_podcast_page_id();
+		}
+
+		// Only find/create when no page was ever assigned.
+		// A stale option (trashed/deleted page) means the user had a page — don't override their choice.
+		if ( get_option( self::OPTION_PODCAST_PAGE_ID ) ) {
+			return 0;
+		}
+
+		return $this->find_or_create_podcast_page();
+	}
+
+	/**
+	 * Creates the podcast archive page on explicit user request.
+	 *
+	 * Unlike create_podcast_archive_page(), this method bypasses the stale-option
+	 * guard — the user clicked "Set up now" and expects a page to be created.
+	 * Restores the previous option value if creation fails.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return int Page ID, or 0 on failure.
+	 */
+	public function setup_podcast_archive_page() {
+		if ( $this->is_podcast_page_assigned() ) {
+			return $this->get_podcast_page_id();
+		}
+
+		$old_page_id = get_option( self::OPTION_PODCAST_PAGE_ID );
+
+		delete_option( self::OPTION_PODCAST_PAGE_ID );
+
+		$page_id = $this->find_or_create_podcast_page();
+
+		if ( ! $page_id && $old_page_id ) {
+			update_option( self::OPTION_PODCAST_PAGE_ID, $old_page_id );
+		}
+
+		return $page_id;
+	}
+
+	/**
+	 * Handles the "Set up now" action from the archive page notice.
+	 *
+	 * Creates the archive page and returns a result array for the caller
+	 * to translate into a flash notice and redirect.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return array{success: bool, message: string, redirect: string}
+	 */
+	public function handle_setup_action() {
+		$page_id = $this->setup_podcast_archive_page();
+
+		if ( ! $page_id ) {
+			return array(
+				'success'  => false,
+				'message'  => __( 'Could not create the episodes page. Please try again or create one manually.', 'seriously-simple-podcasting' ),
+				'redirect' => wp_get_referer() ?: admin_url(),
+			);
+		}
+
+		return array(
+			'success'  => true,
+			'message'  => sprintf(
+				/* translators: %s: link to edit the page */
+				__( 'Your episodes page is ready! You can edit it %s.', 'seriously-simple-podcasting' ),
+				'<a href="' . esc_url( get_edit_post_link( $page_id, 'raw' ) ) . '">' . __( 'here', 'seriously-simple-podcasting' ) . '</a>'
+			),
+			'redirect' => admin_url( 'edit.php?post_type=podcast&page=podcast_settings' ),
+		);
+	}
+
+	/**
+	 * Handles the "Dismiss" action from the archive page notice.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return array{redirect: string}
+	 */
+	public function handle_dismiss_action() {
+		update_option( self::OPTION_NOTICE_DISMISSED, true );
+
+		return array(
+			'redirect' => wp_get_referer() ?: admin_url(),
+		);
+	}
+
+	/**
+	 * Checks whether the archive page upgrade notice should be displayed.
+	 *
+	 * Returns true when no page is assigned and the notice hasn't been dismissed.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return bool
+	 */
+	public function should_show_archive_page_notice() {
+		if ( $this->is_archive_page_notice_dismissed() ) {
+			return false;
+		}
+
+		return ! $this->is_podcast_page_assigned();
+	}
+
+	/**
+	 * Checks whether the archive page upgrade notice has been dismissed.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return bool
+	 */
+	public function is_archive_page_notice_dismissed() {
+		return (bool) get_option( self::OPTION_NOTICE_DISMISSED );
+	}
+
+	/**
+	 * Finds an existing page by slug or creates a new one.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return int Page ID, or 0 on failure.
+	 */
+	protected function find_or_create_podcast_page() {
+		$slug    = apply_filters( 'ssp_podcast_archive_page_slug', self::PODCAST_ARCHIVE_SLUG );
+		$page_id = $this->find_page( $slug );
+
+		if ( $page_id ) {
+			// Ensure the found page is published — it may be in draft, pending, or trash.
+			$page = get_post( $page_id );
+
+			if ( $page && 'publish' !== $page->post_status ) {
+				wp_update_post( array(
+					'ID'          => $page_id,
+					'post_status' => 'publish',
+					'post_name'   => $slug,
+				) );
+			}
+
+			update_option( self::OPTION_PODCAST_PAGE_ID, $page_id );
+
+			return $page_id;
+		}
+
+		return $this->create_page(
+			self::OPTION_PODCAST_PAGE_ID,
+			$slug,
+			__( 'Podcast', 'seriously-simple-podcasting' ),
+			$this->get_podcast_archive_page_content()
+		);
+	}
+}

--- a/php/classes/handlers/class-archive-page-handler.php
+++ b/php/classes/handlers/class-archive-page-handler.php
@@ -215,7 +215,16 @@ class Archive_Page_Handler implements Service {
 	 * @return string
 	 */
 	protected function get_podcast_archive_page_content() {
-		return '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->';
+		$content = '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->';
+
+		/**
+		 * Filters the default block content for newly created podcast archive pages.
+		 *
+		 * @since 3.15.0
+		 *
+		 * @param string $content Default block markup.
+		 */
+		return apply_filters( 'ssp_podcast_archive_page_content', $content );
 	}
 
 	/**
@@ -368,14 +377,40 @@ class Archive_Page_Handler implements Service {
 
 			update_option( self::OPTION_PODCAST_PAGE_ID, $page_id );
 
+			$this->fire_page_created_action( $page_id );
+
 			return $page_id;
 		}
 
-		return $this->create_page(
+		$page_id = $this->create_page(
 			self::OPTION_PODCAST_PAGE_ID,
 			$slug,
 			__( 'Podcast', 'seriously-simple-podcasting' ),
 			$this->get_podcast_archive_page_content()
 		);
+
+		if ( $page_id ) {
+			$this->fire_page_created_action( $page_id );
+		}
+
+		return $page_id;
+	}
+
+	/**
+	 * Fires the archive page created action.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param int $page_id Created or assigned page ID.
+	 */
+	protected function fire_page_created_action( $page_id ) {
+		/**
+		 * Fires after the podcast archive page has been created or assigned.
+		 *
+		 * @since 3.15.0
+		 *
+		 * @param int $page_id The archive page ID.
+		 */
+		do_action( 'ssp_archive_page_created', $page_id );
 	}
 }

--- a/php/classes/handlers/class-archive-page-handler.php
+++ b/php/classes/handlers/class-archive-page-handler.php
@@ -167,6 +167,10 @@ class Archive_Page_Handler implements Service {
 
 		$wp_query->rewind_posts();
 
+		// Enqueue podcast list styles — wp_enqueue_scripts has already fired,
+		// so this outputs in the footer.
+		wp_enqueue_style( 'ssp-podcast-list' );
+
 		// Resolve the page template.
 		$page_template_slug = get_page_template_slug( $page_id );
 
@@ -208,21 +212,28 @@ class Archive_Page_Handler implements Service {
 	}
 
 	/**
-	 * Returns the default block content for the podcast archive page.
+	 * Returns the default content for the podcast archive page.
+	 *
+	 * Uses the Gutenberg block when the block editor is available,
+	 * falls back to the [ssp_episode_list] shortcode for Classic Editor.
 	 *
 	 * @since 3.15.0
 	 *
 	 * @return string
 	 */
 	protected function get_podcast_archive_page_content() {
-		$content = '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->';
+		if ( function_exists( 'use_block_editor_for_post_type' ) && use_block_editor_for_post_type( 'page' ) ) {
+			$content = '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"24"} /-->';
+		} else {
+			$content = '[ssp_episode_list display_image="false" display_excerpt="true" display_player="true" title_size="24"]';
+		}
 
 		/**
-		 * Filters the default block content for newly created podcast archive pages.
+		 * Filters the default content for newly created podcast archive pages.
 		 *
 		 * @since 3.15.0
 		 *
-		 * @param string $content Default block markup.
+		 * @param string $content Default block markup or shortcode.
 		 */
 		return apply_filters( 'ssp_podcast_archive_page_content', $content );
 	}

--- a/php/classes/integrations/blocks/class-castos-blocks.php
+++ b/php/classes/integrations/blocks/class-castos-blocks.php
@@ -41,21 +41,21 @@ class Castos_Blocks {
 	protected $admin_notices_handler;
 
 	/**
-	 * Episode list renderer instance.
+	 * Episode list presenter instance.
 	 *
 	 * @var Episode_List_Presenter
 	 */
-	protected $episode_list_renderer;
+	protected $episode_list_presenter;
 
 	/**
 	 * Castos_Blocks constructor.
 	 *
 	 * @param Admin_Notifications_Handler $admin_notices_handler Admin notifications handler instance.
-	 * @param Episode_List_Presenter       $episode_list_renderer Episode list renderer instance.
+	 * @param Episode_List_Presenter       $episode_list_presenter Episode list presenter instance.
 	 */
-	public function __construct( $admin_notices_handler, $episode_list_renderer ) {
+	public function __construct( $admin_notices_handler, $episode_list_presenter ) {
 		$this->admin_notices_handler = $admin_notices_handler;
-		$this->episode_list_renderer = $episode_list_renderer;
+		$this->episode_list_presenter = $episode_list_presenter;
 
 		if ( ! file_exists( SSP_PLUGIN_PATH . 'build/index.asset.php' ) ) {
 			if ( is_admin() ) {
@@ -80,7 +80,7 @@ class Castos_Blocks {
 		$this->register_deprecated_blocks();
 
 		( new Castos_Html_Player_Block() )->register();
-		( new Podcast_List_Block( $this->episode_list_renderer ) )->register();
+		( new Podcast_List_Block( $this->episode_list_presenter ) )->register();
 		( new Playlist_Player_Block() )->register();
 		( new Ssp_Podcasts_Block() )->register();
 	}

--- a/php/classes/integrations/blocks/class-castos-blocks.php
+++ b/php/classes/integrations/blocks/class-castos-blocks.php
@@ -10,14 +10,8 @@
 
 namespace SeriouslySimplePodcasting\Integrations\Blocks;
 
-use SeriouslySimplePodcasting\Controllers\Players_Controller;
-use SeriouslySimplePodcasting\Entities\Available_Podcasts_Attribute;
-use SeriouslySimplePodcasting\Entities\Available_Tags_Attribute;
 use SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler;
-use SeriouslySimplePodcasting\Renderers\Renderer;
-use SeriouslySimplePodcasting\Repositories\Episode_Repository;
-use SeriouslySimplePodcasting\ShortCodes\Podcast_Playlist;
-use SeriouslySimplePodcasting\Traits\Useful_Variables;
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -25,16 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Blocks class, used to load blocks and any relevant block assets
+ * Blocks coordinator — registers shared editor assets and delegates
+ * block registration to individual block classes.
  *
- * @author      Jonathan Bossenger
- * @category    Class
- * @package     SeriouslySimplePodcasting/Blocks
- * @since       2.0.4
+ * @since 2.0.4
  */
 class Castos_Blocks {
-
-	use Useful_Variables;
 
 	/**
 	 * Asset file array.
@@ -51,42 +41,21 @@ class Castos_Blocks {
 	protected $admin_notices_handler;
 
 	/**
-	 * Episode repository instance.
+	 * Episode list renderer instance.
 	 *
-	 * @var Episode_Repository
+	 * @var Episode_List_Presenter
 	 */
-	protected $episode_repository;
-
-	/**
-	 * Players controller instance.
-	 *
-	 * @var Players_Controller
-	 */
-	protected $players_controller;
-
-	/**
-	 * Renderer instance.
-	 *
-	 * @var Renderer
-	 */
-	protected $renderer;
+	protected $episode_list_renderer;
 
 	/**
 	 * Castos_Blocks constructor.
 	 *
 	 * @param Admin_Notifications_Handler $admin_notices_handler Admin notifications handler instance.
-	 * @param Episode_Repository          $episode_repository    Episode repository instance.
-	 * @param Players_Controller          $players_controller    Players controller instance.
-	 * @param Renderer                    $renderer              Renderer instance.
+	 * @param Episode_List_Presenter       $episode_list_renderer Episode list renderer instance.
 	 */
-	public function __construct( $admin_notices_handler, $episode_repository, $players_controller, $renderer ) {
-
-		$this->init_useful_variables();
-
+	public function __construct( $admin_notices_handler, $episode_list_renderer ) {
 		$this->admin_notices_handler = $admin_notices_handler;
-		$this->episode_repository    = $episode_repository;
-		$this->players_controller    = $players_controller;
-		$this->renderer              = $renderer;
+		$this->episode_list_renderer = $episode_list_renderer;
 
 		if ( ! file_exists( SSP_PLUGIN_PATH . 'build/index.asset.php' ) ) {
 			if ( is_admin() ) {
@@ -102,151 +71,26 @@ class Castos_Blocks {
 	}
 
 	/**
-	 * Dynamic Podcast List Block callback
-	 *
-	 * @param array $attributes Block attributes.
-	 * @return string Rendered block output.
-	 */
-	public function podcast_list_render_callback( $attributes ) {
-		$paged            = filter_input( INPUT_GET, 'podcast_page' );
-		$paged            = $paged ? $paged : 1;
-		$allowed_order_by = array( 'ID', 'title', 'date', 'recorded' );
-
-		$query_args = array(
-			'post_type'      => ssp_post_types(),
-			'podcast_id'     => ( '' === $attributes['selectedPodcast'] ) ? -1 : intval( $attributes['selectedPodcast'] ),
-			'posts_per_page' => intval( isset( $attributes['postsPerPage'] ) ? $attributes['postsPerPage'] : get_option( 'posts_per_page', 10 ) ),
-			'paged'          => $paged,
-			'orderby'        => in_array( $attributes['orderBy'], $allowed_order_by, true ) ? $attributes['orderBy'] : 'date',
-			'order'          => 'asc' === $attributes['order'] ? 'asc' : 'desc',
-		);
-
-		$episodes_query = $this->get_podcast_list_episodes_query( $query_args );
-
-		// We can't use get_next_posts_link() because it doesn't work on single pages.
-		$paginate = $this->get_podcast_list_paginate_links( $episodes_query, $paged );
-
-		$args = array(
-			'episode_repository'  => $this->episode_repository,
-			'players_controller'  => $this->players_controller,
-			'permalink_structure' => get_option( 'permalink_structure' ),
-			'show_player'         => boolval( $attributes['player'] ),
-			'player_style'        => get_option( 'ss_podcasting_player_style', '' ),
-			'episodes_query'      => $episodes_query,
-			'paginate'            => $paginate,
-			'show_title'          => boolval( $attributes['showTitle'] ),
-			'show_img'            => boolval( $attributes['featuredImage'] ),
-			'img_size'            => strval( $attributes['featuredImageSize'] ),
-			'is_player_below'     => boolval( $attributes['playerBelowExcerpt'] ),
-			'show_excerpt'        => boolval( $attributes['excerpt'] ),
-			'columns_per_row'     => intval( $attributes['columnsPerRow'] ),
-			'title_size'          => intval( $attributes['titleSize'] ),
-			'title_under_img'     => intval( $attributes['titleUnderImage'] ),
-		);
-
-		$podcast_list = $this->renderer->fetch( 'blocks/podcast-list', $args );
-
-		return apply_filters( 'podcast_list_dynamic_block_html_content', $podcast_list );
-	}
-
-	/**
-	 * Gets podcast list episodes query.
-	 *
-	 * @param array $args Query arguments.
-	 * @return \WP_Query Query object.
-	 */
-	protected function get_podcast_list_episodes_query( $args ) {
-
-		$defaults = array(
-			'post_status'    => 'publish',
-			'post_type'      => SSP_CPT_PODCAST,
-			'podcast_id'     => - 1,
-			'posts_per_page' => 10,
-			'paged'          => 1,
-			'orderby'        => 'date',
-			'order'          => 'desc',
-			'meta_query'     => array(
-				array(
-					'key'     => 'audio_file',
-					'compare' => '!=',
-					'value'   => '',
-				),
-			),
-		);
-
-		$query_args = wp_parse_args( $args, $defaults );
-
-		// Fix for the new Default Series, now 0 becomes default series ID.
-		if ( ! $query_args['podcast_id'] ) {
-			$query_args['podcast_id'] = ssp_get_default_series_id();
-		}
-
-		// -1 stands for all episodes ( option "-- All --" ).
-		if ( - 1 !== $query_args['podcast_id'] ) {
-			$tax_query = array(
-				'taxonomy' => ssp_series_taxonomy(),
-			);
-
-			if ( $query_args['podcast_id'] ) {
-				$tax_query['field'] = 'id';
-				$tax_query['terms'] = $query_args['podcast_id'];
-			} else {
-				$tax_query['operator'] = 'NOT EXISTS';
-			}
-			$query_args['tax_query'] = array( $tax_query );
-		}
-
-		if ( 'recorded' === $query_args['orderby'] ) {
-			$query_args['orderby']  = 'meta_value';
-			$query_args['meta_key'] = 'date_recorded';
-		}
-
-		$query_args = apply_filters( 'podcast_list_dynamic_block_query_arguments', $query_args );
-
-		return new \WP_Query( $query_args );
-	}
-
-	/**
-	 * Gets podcast list paginate links.
-	 *
-	 * @param \WP_Query $episodes_query Episodes query object.
-	 * @param int       $current_page   Current page number.
-	 * @return array Paginate links array.
-	 */
-	protected function get_podcast_list_paginate_links( $episodes_query, $current_page ) {
-		$args = array(
-			'format'    => '?podcast_page=%#%',
-			'total'     => $episodes_query->max_num_pages,
-			'current'   => $current_page,
-			'prev_text' => __( '&laquo; Newer Episodes' ),
-			'next_text' => __( 'Older Episodes &raquo;' ),
-			'type'      => 'array',
-		);
-
-		$args = apply_filters( 'ssp_podcast_list_paginate_args', $args, $episodes_query );
-
-		$all_links = paginate_links( $args );
-
-		$links = array();
-
-		if ( is_array( $all_links ) ) {
-			foreach ( $all_links as $item ) {
-				if ( strpos( $item, 'class="next' ) || strpos( $item, 'class="prev' ) ) {
-					$links[] = $item;
-				}
-			}
-		}
-
-		return apply_filters( 'ssp_podcast_list_paginate_links', $links, $all_links, $episodes_query );
-	}
-
-	/**
-	 * Registers the Castos Player Block
+	 * Registers shared editor assets, deprecated block stubs, and active blocks.
 	 *
 	 * @return void
 	 */
 	public function register_castos_blocks() {
+		$this->register_shared_assets();
+		$this->register_deprecated_blocks();
 
+		( new Castos_Html_Player_Block() )->register();
+		( new Podcast_List_Block( $this->episode_list_renderer ) )->register();
+		( new Playlist_Player_Block() )->register();
+		( new Ssp_Podcasts_Block() )->register();
+	}
+
+	/**
+	 * Registers shared editor script and styles used by all blocks.
+	 *
+	 * @return void
+	 */
+	protected function register_shared_assets() {
 		$dependencies = $this->asset_file['dependencies'];
 
 		// Dependency wp-edit-post is needed only for PostPublishPanel block, and it leads to a warning on widgets page.
@@ -279,7 +123,18 @@ class Castos_Blocks {
 			array(),
 			$this->asset_file['version']
 		);
+	}
 
+	/**
+	 * Registers deprecated blocks for backward compatibility with existing posts.
+	 *
+	 * @return void
+	 */
+	protected function register_deprecated_blocks() {
+		/**
+		 * @deprecated Use 'seriously-simple-podcasting/castos-html-player' instead.
+		 *             Kept registered for backward compatibility with existing posts.
+		 */
 		register_block_type(
 			'seriously-simple-podcasting/castos-player',
 			array(
@@ -289,317 +144,14 @@ class Castos_Blocks {
 		);
 
 		/**
-		 * Is used for both rendering the block itself and preview in editor
-		 *
-		 * @since 2.8.2
-		 * */
-		register_block_type(
-			'seriously-simple-podcasting/castos-html-player',
-			array(
-				'editor_script'   => 'ssp-block-script',
-				'editor_style'    => 'ssp-castos-player',
-				'attributes'      => array(
-					'episodeId' => array(
-						'type'    => 'string',
-						'default' => '',
-					),
-				),
-				'render_callback' => function ( $args ) {
-					return ssp_frontend_controller()->players_controller->render_html_player( $args['episodeId'], true, 'block', $args );
-				},
-			)
-		);
-
+		 * @deprecated Use 'seriously-simple-podcasting/castos-html-player' instead.
+		 *             Kept registered for backward compatibility with existing posts.
+		 */
 		register_block_type(
 			'seriously-simple-podcasting/audio-player',
 			array(
 				'editor_script' => 'ssp-block-script',
 			)
 		);
-
-		$this->register_podcast_list();
-		$this->register_playlist_player();
-		( new Ssp_Podcasts_Block() )->register();
-	}
-
-
-
-	/**
-	 * Registers the podcast list block.
-	 *
-	 * @return void
-	 */
-	protected function register_podcast_list() {
-
-		wp_register_style( 'ssp-podcast-list', esc_url( $this->assets_url . 'css/blocks/podcast-list' . $this->script_suffix . '.css' ), array(), $this->version );
-
-		add_action(
-			'admin_enqueue_scripts',
-			function () {
-				wp_enqueue_style( 'ssp-podcast-list' );
-			}
-		);
-
-		add_action(
-			'wp_enqueue_scripts',
-			function () {
-				if ( function_exists( 'has_block' ) && has_block( 'seriously-simple-podcasting/podcast-list' ) ) {
-					wp_enqueue_style( 'ssp-podcast-list' );
-				}
-			}
-		);
-
-		$default_series_id = ssp_get_default_series_id();
-
-		register_block_type(
-			'seriously-simple-podcasting/podcast-list',
-			array(
-				'editor_script'   => 'ssp-block-script',
-				'editor_style'    => 'ssp-block-style',
-				'attributes'      => array(
-					'showTitle'           => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
-					'featuredImage'       => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
-					'availableImageSizes' => array(
-						'type'    => 'array',
-						'default' => array_merge(
-							array(
-								array(
-									'label' => 'Full',
-									'value' => 'full',
-								),
-							),
-							array_map(
-								function ( $item ) {
-									return array(
-										'label' => ucfirst( $item ),
-										'value' => $item,
-									);
-								},
-								get_intermediate_image_sizes()
-							)
-						),
-					),
-					'featuredImageSize'   => array(
-						'type'    => 'string',
-						'default' => 'full',
-					),
-					'excerpt'             => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-					'player'              => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-					'playerBelowExcerpt'  => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-					'availablePodcasts'   => array(
-						'type'    => 'array',
-						'default' => $this->get_podcast_settings(),
-					),
-					'selectedPodcast'     => array(
-						'type'    => 'string',
-						'default' => '-1',
-					),
-					'defaultPodcastId'    => array(
-						'type'    => 'string',
-						'default' => strval( $default_series_id ),
-					),
-					// Use string everywhere instead of number because of the WP bug.
-					// It doesn't show the saved value in the admin after page refresh.
-					'postsPerPage'        => array(
-						'type'    => 'string',
-						'default' => 0,
-					),
-					'orderBy'             => array(
-						'type'    => 'string',
-						'default' => 'date',
-					),
-					'order'               => array(
-						'type'    => 'string',
-						'default' => 'desc',
-					),
-					'columnsPerRow'       => array(
-						'type'    => 'string',
-						'default' => 1,
-					),
-					'titleSize'           => array(
-						'type'    => 'string',
-						'default' => 16,
-					),
-					'titleUnderImage'     => array(
-						'type'    => 'boolean',
-						'default' => false,
-					),
-				),
-				'render_callback' => array(
-					$this,
-					'podcast_list_render_callback',
-				),
-			)
-		);
-	}
-
-	/**
-	 * Registers the playlist player block.
-	 *
-	 * @return void
-	 */
-	protected function register_playlist_player() {
-
-		register_block_type(
-			'seriously-simple-podcasting/playlist-player',
-			array(
-				'attributes'      => array(
-					'availablePodcasts' => array(
-						'type'    => 'array',
-						'default' => new Available_Podcasts_Attribute(),
-					),
-					'selectedPodcast'   => array(
-						'type'    => 'string',
-						'default' => '-1',
-					),
-					'availableTags'     => array(
-						'type'    => 'array',
-						'default' => new Available_Tags_Attribute(),
-					),
-					'selectedTag'       => array(
-						'type'    => 'string',
-						'default' => '',
-					),
-					// Use string everywhere instead of number because of the WP bug.
-					// It doesn't show the saved value in the admin after page refresh.
-					'limit'             => array(
-						'type'    => 'string',
-						'default' => -1,
-					),
-					'orderBy'           => array(
-						'type'    => 'string',
-						'default' => 'date',
-					),
-					'order'             => array(
-						'type'    => 'string',
-						'default' => 'desc',
-					),
-				),
-				'render_callback' => function ( $attributes ) {
-					$podcast_id = ( '' === $attributes['selectedPodcast'] ) ? - 1 : intval( $attributes['selectedPodcast'] );
-					$args       = array();
-
-					if ( $podcast_id ) {
-						$args['series'] = $this->get_term_slug_by_id( $podcast_id );
-					}
-
-					if ( ! empty( $attributes['selectedTag'] ) ) {
-						$args['tag'] = $attributes['selectedTag'];
-					}
-
-					if ( ! empty( $attributes['limit'] ) ) {
-						$args['limit'] = $attributes['limit'];
-					}
-
-					if ( ! empty( $attributes['orderBy'] ) ) {
-						$args['orderby'] = $attributes['orderBy'];
-					}
-
-					if ( ! empty( $attributes['order'] ) ) {
-						$args['order'] = $attributes['order'];
-					}
-
-					if ( ! empty( $attributes['className'] ) ) {
-						$args['class'] = $attributes['className'];
-					}
-
-					$podcast_playlist = new Podcast_Playlist();
-
-					return $podcast_playlist->shortcode( $args );
-				},
-			)
-		);
-	}
-
-
-	/**
-	 * Gets term slug by ID.
-	 *
-	 * @param int $term_id Term ID.
-	 * @return string|null Term slug or null if not found.
-	 */
-	protected function get_term_slug_by_id( $term_id ) {
-		$term = get_term_by( 'id', $term_id, ssp_series_taxonomy() );
-		if ( $term ) {
-			return $term->slug;
-		}
-		return null;
-	}
-
-	/**
-	 * Gets podcast settings for block attributes.
-	 *
-	 * @return array Podcast settings array.
-	 */
-	protected function get_podcast_settings() {
-		$default_series_id = ssp_get_default_series_id();
-
-		return array_merge(
-			array(
-				array(
-					'label' => __( '-- All --', 'seriously-simple-podcasting' ),
-					'value' => - 1,
-				),
-			),
-			array_map(
-				function ( $item ) use ( $default_series_id ) {
-					$label = $default_series_id === $item->term_id ?
-					ssp_get_default_series_name( $item->name ) :
-					$item->name;
-
-					return array(
-						'label' => $label,
-						'value' => $item->term_id,
-					);
-				},
-				ssp_get_podcasts()
-			)
-		);
-	}
-
-	/**
-	 * Gets tag settings for block attributes.
-	 *
-	 * @return array Tag settings array.
-	 */
-	protected function get_tag_settings() {
-		$settings = array(
-			array(
-				'label' => __( '-- All --', 'seriously-simple-podcasting' ),
-				'value' => '',
-			),
-		);
-
-		if ( is_admin() ) {
-			$settings = array_merge(
-				$settings,
-				array_map(
-					function ( $item ) {
-						return array(
-							'label' => $item->name,
-							'value' => $item->slug,
-						);
-					},
-					ssp_get_tags()
-				)
-			);
-		}
-
-		return $settings;
 	}
 }

--- a/php/classes/integrations/blocks/class-castos-html-player-block.php
+++ b/php/classes/integrations/blocks/class-castos-html-player-block.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SeriouslySimplePodcasting\Integrations\Blocks;
+
+/**
+ * Handles registration and rendering of the `seriously-simple-podcasting/castos-html-player` block.
+ *
+ * @package Seriously Simple Podcasting
+ * @since 2.8.2
+ */
+class Castos_Html_Player_Block {
+
+	/**
+	 * Registers the block type.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		register_block_type(
+			'seriously-simple-podcasting/castos-html-player',
+			array(
+				'editor_script'   => 'ssp-block-script',
+				'editor_style'    => 'ssp-castos-player',
+				'attributes'      => array(
+					'episodeId' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+				'render_callback' => array( $this, 'render_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Render callback for the Castos HTML Player block.
+	 *
+	 * @param array $args Block attributes.
+	 *
+	 * @return string Rendered player HTML.
+	 */
+	public function render_callback( $args ) {
+		return ssp_frontend_controller()->players_controller->render_html_player( $args['episodeId'], true, 'block', $args );
+	}
+}

--- a/php/classes/integrations/blocks/class-playlist-player-block.php
+++ b/php/classes/integrations/blocks/class-playlist-player-block.php
@@ -71,7 +71,7 @@ class Playlist_Player_Block {
 		$podcast_id = ( '' === $attributes['selectedPodcast'] ) ? -1 : intval( $attributes['selectedPodcast'] );
 		$args       = array();
 
-		if ( $podcast_id ) {
+		if ( $podcast_id > 0 ) {
 			$args['series'] = $this->get_term_slug_by_id( $podcast_id );
 		}
 

--- a/php/classes/integrations/blocks/class-playlist-player-block.php
+++ b/php/classes/integrations/blocks/class-playlist-player-block.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace SeriouslySimplePodcasting\Integrations\Blocks;
+
+use SeriouslySimplePodcasting\Entities\Available_Podcasts_Attribute;
+use SeriouslySimplePodcasting\Entities\Available_Tags_Attribute;
+use SeriouslySimplePodcasting\ShortCodes\Podcast_Playlist;
+
+/**
+ * Handles registration and rendering of the `seriously-simple-podcasting/playlist-player` block.
+ *
+ * @package Seriously Simple Podcasting
+ * @since 2.0.4
+ */
+class Playlist_Player_Block {
+
+	/**
+	 * Registers the block type.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		register_block_type(
+			'seriously-simple-podcasting/playlist-player',
+			array(
+				'attributes'      => array(
+					'availablePodcasts' => array(
+						'type'    => 'array',
+						'default' => new Available_Podcasts_Attribute(),
+					),
+					'selectedPodcast'   => array(
+						'type'    => 'string',
+						'default' => '-1',
+					),
+					'availableTags'     => array(
+						'type'    => 'array',
+						'default' => new Available_Tags_Attribute(),
+					),
+					'selectedTag'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					// Use string everywhere instead of number because of the WP bug.
+					// It doesn't show the saved value in the admin after page refresh.
+					'limit'             => array(
+						'type'    => 'string',
+						'default' => -1,
+					),
+					'orderBy'           => array(
+						'type'    => 'string',
+						'default' => 'date',
+					),
+					'order'             => array(
+						'type'    => 'string',
+						'default' => 'desc',
+					),
+				),
+				'render_callback' => array( $this, 'render_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Render callback for the playlist player block.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string Rendered playlist HTML.
+	 */
+	public function render_callback( $attributes ) {
+		$podcast_id = ( '' === $attributes['selectedPodcast'] ) ? -1 : intval( $attributes['selectedPodcast'] );
+		$args       = array();
+
+		if ( $podcast_id ) {
+			$args['series'] = $this->get_term_slug_by_id( $podcast_id );
+		}
+
+		if ( ! empty( $attributes['selectedTag'] ) ) {
+			$args['tag'] = $attributes['selectedTag'];
+		}
+
+		if ( ! empty( $attributes['limit'] ) ) {
+			$args['limit'] = $attributes['limit'];
+		}
+
+		if ( ! empty( $attributes['orderBy'] ) ) {
+			$args['orderby'] = $attributes['orderBy'];
+		}
+
+		if ( ! empty( $attributes['order'] ) ) {
+			$args['order'] = $attributes['order'];
+		}
+
+		if ( ! empty( $attributes['className'] ) ) {
+			$args['class'] = $attributes['className'];
+		}
+
+		$podcast_playlist = new Podcast_Playlist();
+
+		return $podcast_playlist->shortcode( $args );
+	}
+
+	/**
+	 * Gets term slug by ID.
+	 *
+	 * @param int $term_id Term ID.
+	 *
+	 * @return string|null Term slug or null if not found.
+	 */
+	protected function get_term_slug_by_id( $term_id ) {
+		$term = get_term_by( 'id', $term_id, ssp_series_taxonomy() );
+
+		if ( $term ) {
+			return $term->slug;
+		}
+
+		return null;
+	}
+}

--- a/php/classes/integrations/blocks/class-podcast-list-block.php
+++ b/php/classes/integrations/blocks/class-podcast-list-block.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace SeriouslySimplePodcasting\Integrations\Blocks;
+
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
+use SeriouslySimplePodcasting\Traits\Useful_Variables;
+
+/**
+ * Handles registration and rendering of the `seriously-simple-podcasting/podcast-list` block.
+ *
+ * @package Seriously Simple Podcasting
+ * @since 2.0.4
+ */
+class Podcast_List_Block {
+
+	use Useful_Variables;
+
+	/**
+	 * @var Episode_List_Presenter
+	 */
+	protected $episode_list_renderer;
+
+	/**
+	 * @param Episode_List_Presenter $episode_list_renderer Episode list renderer instance.
+	 */
+	public function __construct( $episode_list_renderer ) {
+		$this->episode_list_renderer = $episode_list_renderer;
+		$this->init_useful_variables();
+	}
+
+	/**
+	 * Registers the block type and related assets.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		wp_register_style( 'ssp-podcast-list', esc_url( $this->assets_url . 'css/blocks/podcast-list' . $this->script_suffix . '.css' ), array(), $this->version );
+
+		add_action(
+			'admin_enqueue_scripts',
+			function () {
+				wp_enqueue_style( 'ssp-podcast-list' );
+			}
+		);
+
+		add_action(
+			'wp_enqueue_scripts',
+			function () {
+				if ( function_exists( 'has_block' ) && has_block( 'seriously-simple-podcasting/podcast-list' ) ) {
+					wp_enqueue_style( 'ssp-podcast-list' );
+				}
+			}
+		);
+
+		$default_series_id = ssp_get_default_series_id();
+
+		register_block_type(
+			'seriously-simple-podcasting/podcast-list',
+			array(
+				'editor_script'   => 'ssp-block-script',
+				'editor_style'    => 'ssp-block-style',
+				'attributes'      => array(
+					'showTitle'           => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'featuredImage'       => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'availableImageSizes' => array(
+						'type'    => 'array',
+						'default' => array_merge(
+							array(
+								array(
+									'label' => 'Full',
+									'value' => 'full',
+								),
+							),
+							array_map(
+								function ( $item ) {
+									return array(
+										'label' => ucfirst( $item ),
+										'value' => $item,
+									);
+								},
+								get_intermediate_image_sizes()
+							)
+						),
+					),
+					'featuredImageSize'   => array(
+						'type'    => 'string',
+						'default' => 'full',
+					),
+					'excerpt'             => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'player'              => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'playerBelowExcerpt'  => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'availablePodcasts'   => array(
+						'type'    => 'array',
+						'default' => $this->get_podcast_settings(),
+					),
+					'selectedPodcast'     => array(
+						'type'    => 'string',
+						'default' => '-1',
+					),
+					'defaultPodcastId'    => array(
+						'type'    => 'string',
+						'default' => strval( $default_series_id ),
+					),
+					// Use string everywhere instead of number because of the WP bug.
+					// It doesn't show the saved value in the admin after page refresh.
+					'postsPerPage'        => array(
+						'type'    => 'string',
+						'default' => 0,
+					),
+					'orderBy'             => array(
+						'type'    => 'string',
+						'default' => 'date',
+					),
+					'order'               => array(
+						'type'    => 'string',
+						'default' => 'desc',
+					),
+					'columnsPerRow'       => array(
+						'type'    => 'string',
+						'default' => 1,
+					),
+					'titleSize'           => array(
+						'type'    => 'string',
+						'default' => 16,
+					),
+					'titleUnderImage'     => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+				),
+				'render_callback' => array( $this, 'render_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Render callback for the podcast list block.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string Rendered block output.
+	 */
+	public function render_callback( $attributes ) {
+		return $this->episode_list_renderer->render( $attributes );
+	}
+
+	/**
+	 * Gets podcast settings for block attributes.
+	 *
+	 * @return array
+	 */
+	protected function get_podcast_settings() {
+		$default_series_id = ssp_get_default_series_id();
+
+		return array_merge(
+			array(
+				array(
+					'label' => __( '-- All --', 'seriously-simple-podcasting' ),
+					'value' => -1,
+				),
+			),
+			array_map(
+				function ( $item ) use ( $default_series_id ) {
+					$label = $default_series_id === $item->term_id ?
+						ssp_get_default_series_name( $item->name ) :
+						$item->name;
+
+					return array(
+						'label' => $label,
+						'value' => $item->term_id,
+					);
+				},
+				ssp_get_podcasts()
+			)
+		);
+	}
+}

--- a/php/classes/integrations/blocks/class-podcast-list-block.php
+++ b/php/classes/integrations/blocks/class-podcast-list-block.php
@@ -18,13 +18,13 @@ class Podcast_List_Block {
 	/**
 	 * @var Episode_List_Presenter
 	 */
-	protected $episode_list_renderer;
+	protected $episode_list_presenter;
 
 	/**
-	 * @param Episode_List_Presenter $episode_list_renderer Episode list renderer instance.
+	 * @param Episode_List_Presenter $episode_list_presenter Episode list presenter instance.
 	 */
-	public function __construct( $episode_list_renderer ) {
-		$this->episode_list_renderer = $episode_list_renderer;
+	public function __construct( $episode_list_presenter ) {
+		$this->episode_list_presenter = $episode_list_presenter;
 		$this->init_useful_variables();
 	}
 
@@ -156,7 +156,7 @@ class Podcast_List_Block {
 	 * @return string Rendered block output.
 	 */
 	public function render_callback( $attributes ) {
-		return $this->episode_list_renderer->render( $attributes );
+		return $this->episode_list_presenter->render( $attributes );
 	}
 
 	/**

--- a/php/classes/presenters/class-episode-list-presenter.php
+++ b/php/classes/presenters/class-episode-list-presenter.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace SeriouslySimplePodcasting\Presenters;
+
+use SeriouslySimplePodcasting\Controllers\Players_Controller;
+use SeriouslySimplePodcasting\Renderers\Renderer;
+use SeriouslySimplePodcasting\Repositories\Episode_Repository;
+
+/**
+ * Prepares and renders the episode list used by the podcast-list block,
+ * [ssp_episode_list] shortcode, and any other delivery mechanism.
+ *
+ * Presenters own the data-fetching, transformation, and rendering orchestration
+ * for a specific UI component. They are consumed by blocks, shortcodes, and widgets.
+ *
+ * @package Seriously Simple Podcasting
+ * @since 3.15.0
+ */
+class Episode_List_Presenter {
+
+	/**
+	 * @var Episode_Repository
+	 */
+	protected $episode_repository;
+
+	/**
+	 * @var Players_Controller
+	 */
+	protected $players_controller;
+
+	/**
+	 * @var Renderer
+	 */
+	protected $renderer;
+
+	/**
+	 * @param Episode_Repository $episode_repository Episode repository instance.
+	 * @param Players_Controller $players_controller Players controller instance.
+	 * @param Renderer           $renderer           Renderer instance.
+	 */
+	public function __construct( $episode_repository, $players_controller, $renderer ) {
+		$this->episode_repository = $episode_repository;
+		$this->players_controller = $players_controller;
+		$this->renderer           = $renderer;
+	}
+
+	/**
+	 * Renders the episode list HTML.
+	 *
+	 * Accepts the same attribute format as the podcast-list block.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param array $attributes Render attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	public function render( $attributes ) {
+		$query_args     = $this->normalize_attributes( $attributes );
+		$episodes_query = $this->build_query( $query_args );
+		$paginate       = $this->paginate( $episodes_query, $query_args['paged'] );
+		$template_args  = $this->prepare_template_args( $attributes, $episodes_query, $paginate );
+
+		$html = $this->renderer->fetch( 'blocks/podcast-list', $template_args );
+
+		return apply_filters( 'podcast_list_dynamic_block_html_content', $html );
+	}
+
+	/**
+	 * Converts block/shortcode attributes into WP_Query arguments.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param array $attributes Raw attributes from block or shortcode.
+	 *
+	 * @return array Query arguments.
+	 */
+	protected function normalize_attributes( $attributes ) {
+		$paged            = filter_input( INPUT_GET, 'podcast_page' );
+		$paged            = $paged ? $paged : 1;
+		$allowed_order_by = array( 'ID', 'title', 'date', 'recorded' );
+
+		return array(
+			'post_type'      => ssp_post_types(),
+			'podcast_id'     => ( '' === $attributes['selectedPodcast'] ) ? -1 : intval( $attributes['selectedPodcast'] ),
+			'posts_per_page' => intval( isset( $attributes['postsPerPage'] ) ? $attributes['postsPerPage'] : get_option( 'posts_per_page', 10 ) ),
+			'paged'          => $paged,
+			'orderby'        => in_array( $attributes['orderBy'], $allowed_order_by, true ) ? $attributes['orderBy'] : 'date',
+			'order'          => 'asc' === $attributes['order'] ? 'asc' : 'desc',
+		);
+	}
+
+	/**
+	 * Prepares the template arguments from attributes, query, and pagination.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param array     $attributes     Raw attributes from block or shortcode.
+	 * @param \WP_Query $episodes_query Episodes query result.
+	 * @param array     $paginate       Pagination links.
+	 *
+	 * @return array Template arguments for the episode list template.
+	 */
+	protected function prepare_template_args( $attributes, $episodes_query, $paginate ) {
+		return array(
+			'episode_repository'  => $this->episode_repository,
+			'players_controller'  => $this->players_controller,
+			'permalink_structure' => get_option( 'permalink_structure' ),
+			'show_player'         => boolval( $attributes['player'] ),
+			'player_style'        => get_option( 'ss_podcasting_player_style', '' ),
+			'episodes_query'      => $episodes_query,
+			'paginate'            => $paginate,
+			'show_title'          => boolval( $attributes['showTitle'] ),
+			'show_img'            => boolval( $attributes['featuredImage'] ),
+			'img_size'            => strval( $attributes['featuredImageSize'] ),
+			'is_player_below'     => boolval( $attributes['playerBelowExcerpt'] ),
+			'show_excerpt'        => boolval( $attributes['excerpt'] ),
+			'columns_per_row'     => intval( $attributes['columnsPerRow'] ),
+			'title_size'          => intval( $attributes['titleSize'] ),
+			'title_under_img'     => intval( $attributes['titleUnderImage'] ),
+		);
+	}
+
+	/**
+	 * Builds the episode list WP_Query.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param array $args Query arguments.
+	 *
+	 * @return \WP_Query
+	 */
+	public function build_query( $args ) {
+		$defaults = array(
+			'post_status'    => 'publish',
+			'post_type'      => SSP_CPT_PODCAST,
+			'podcast_id'     => -1,
+			'posts_per_page' => 10,
+			'paged'          => 1,
+			'orderby'        => 'date',
+			'order'          => 'desc',
+			'meta_query'     => array(
+				array(
+					'key'     => 'audio_file',
+					'compare' => '!=',
+					'value'   => '',
+				),
+			),
+		);
+
+		$query_args = wp_parse_args( $args, $defaults );
+
+		// Fix for the new Default Series, now 0 becomes default series ID.
+		if ( ! $query_args['podcast_id'] ) {
+			$query_args['podcast_id'] = ssp_get_default_series_id();
+		}
+
+		// -1 stands for all episodes ( option "-- All --" ).
+		if ( -1 !== $query_args['podcast_id'] ) {
+			$tax_query = array(
+				'taxonomy' => ssp_series_taxonomy(),
+			);
+
+			if ( $query_args['podcast_id'] ) {
+				$tax_query['field'] = 'id';
+				$tax_query['terms'] = $query_args['podcast_id'];
+			} else {
+				$tax_query['operator'] = 'NOT EXISTS';
+			}
+			$query_args['tax_query'] = array( $tax_query );
+		}
+
+		if ( 'recorded' === $query_args['orderby'] ) {
+			$query_args['orderby']  = 'meta_value';
+			$query_args['meta_key'] = 'date_recorded';
+		}
+
+		$query_args = apply_filters( 'podcast_list_dynamic_block_query_arguments', $query_args );
+
+		return new \WP_Query( $query_args );
+	}
+
+	/**
+	 * Generates pagination links for the episode list.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param \WP_Query $episodes_query Episodes query object.
+	 * @param int       $current_page   Current page number.
+	 *
+	 * @return array Paginate links array.
+	 */
+	public function paginate( $episodes_query, $current_page ) {
+		$args = array(
+			'format'    => '?podcast_page=%#%',
+			'total'     => $episodes_query->max_num_pages,
+			'current'   => $current_page,
+			'prev_text' => __( '&laquo; Newer Episodes' ),
+			'next_text' => __( 'Older Episodes &raquo;' ),
+			'type'      => 'array',
+		);
+
+		$args = apply_filters( 'ssp_podcast_list_paginate_args', $args, $episodes_query );
+
+		$all_links = paginate_links( $args );
+
+		$links = array();
+
+		if ( is_array( $all_links ) ) {
+			foreach ( $all_links as $item ) {
+				if ( strpos( $item, 'class="next' ) || strpos( $item, 'class="prev' ) ) {
+					$links[] = $item;
+				}
+			}
+		}
+
+		return apply_filters( 'ssp_podcast_list_paginate_links', $links, $all_links, $episodes_query );
+	}
+}

--- a/php/classes/presenters/class-episode-list-presenter.php
+++ b/php/classes/presenters/class-episode-list-presenter.php
@@ -195,8 +195,8 @@ class Episode_List_Presenter {
 			'format'    => '?podcast_page=%#%',
 			'total'     => $episodes_query->max_num_pages,
 			'current'   => $current_page,
-			'prev_text' => __( '&laquo; Newer Episodes' ),
-			'next_text' => __( 'Older Episodes &raquo;' ),
+			'prev_text' => __( '&laquo; Newer Episodes', 'seriously-simple-podcasting' ),
+			'next_text' => __( 'Older Episodes &raquo;', 'seriously-simple-podcasting' ),
 			'type'      => 'array',
 		);
 

--- a/php/classes/renderers/class-settings-renderer.php
+++ b/php/classes/renderers/class-settings-renderer.php
@@ -120,6 +120,10 @@ class Settings_Renderer implements Service {
 				break;
 			case 'podcasts_sync':
 				$html .= $this->render_sync_podcasts( $field, $data, $option_name );
+				break;
+			case 'single_select_page':
+				$html .= $this->render_single_select_page( $field, $data, $option_name );
+				break;
 		}
 
 		if ( ! in_array(
@@ -453,6 +457,45 @@ class Settings_Renderer implements Service {
 						'" class="' . $this->get_field_class( $field ) . '"> ' . $v . '</option>';
 		}
 		$html .= '</select>';
+
+		return $html;
+	}
+
+	/**
+	 * Renders a searchable page dropdown using wp_dropdown_pages with Select2.
+	 *
+	 * @param array  $field       Field configuration array.
+	 * @param string $data        Current field value (page ID).
+	 * @param string $option_name Option name for form submission.
+	 *
+	 * @return string
+	 * @since 3.15.0
+	 */
+	protected function render_single_select_page( $field, $data, $option_name ) {
+		$args = array(
+			'name'             => esc_attr( $option_name ),
+			'id'               => esc_attr( $field['id'] ),
+			'sort_column'      => 'menu_order',
+			'sort_order'       => 'ASC',
+			'show_option_none' => __( '— Select a page —', 'seriously-simple-podcasting' ),
+			'option_none_value' => '',
+			'echo'             => false,
+			'selected'         => absint( $data ),
+			'post_status'      => 'publish,private,draft',
+		);
+
+		$html = wp_dropdown_pages( $args );
+
+		// Append page IDs to option labels (e.g. "Podcast (ID: 42)") for clarity.
+		$html = preg_replace_callback(
+			'/(<option[^>]*value="(\d+)"[^>]*>)([^<]+)/',
+			function ( $matches ) {
+				return $matches[1] . $matches[3] . ' (ID: ' . $matches[2] . ')';
+			},
+			$html
+		);
+
+		$html = str_replace( '<select', '<select class="js-ssp-select2"', $html );
 
 		return $html;
 	}

--- a/php/classes/shortcodes/class-episode-list.php
+++ b/php/classes/shortcodes/class-episode-list.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Episode List shortcode class.
+ *
+ * Renders the same episode list as the podcast-list Gutenberg block,
+ * using the shared Episode_List_Presenter.
+ *
+ * @package SeriouslySimplePodcasting
+ * @since 3.15.0
+ */
+
+namespace SeriouslySimplePodcasting\ShortCodes;
+
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Episode List Shortcode
+ *
+ * @author     Serhiy Zakharchenko
+ * @package    SeriouslySimplePodcasting
+ * @since      3.15.0
+ */
+class Episode_List implements Shortcode {
+
+	/**
+	 * Snake_case shortcode attr => camelCase presenter attr.
+	 *
+	 * @since 3.15.0
+	 */
+	const ATTRIBUTE_MAP = array(
+		'podcast_id'           => array(
+			'key'  => 'selectedPodcast',
+			'type' => 'string',
+		),
+		'posts_per_page'       => array(
+			'key'  => 'postsPerPage',
+			'type' => 'string',
+		),
+		'order_by'             => array(
+			'key'  => 'orderBy',
+			'type' => 'string',
+		),
+		'order'                => array(
+			'key'  => 'order',
+			'type' => 'string',
+		),
+		'columns'              => array(
+			'key'  => 'columnsPerRow',
+			'type' => 'string',
+		),
+		'display_player'       => array(
+			'key'  => 'player',
+			'type' => 'bool',
+		),
+		'display_excerpt'      => array(
+			'key'  => 'excerpt',
+			'type' => 'bool',
+		),
+		'display_title'        => array(
+			'key'  => 'showTitle',
+			'type' => 'bool',
+		),
+		'display_image'        => array(
+			'key'  => 'featuredImage',
+			'type' => 'bool',
+		),
+		'image_size'           => array(
+			'key'  => 'featuredImageSize',
+			'type' => 'string',
+		),
+		'title_size'           => array(
+			'key'  => 'titleSize',
+			'type' => 'string',
+		),
+		'title_under_image'    => array(
+			'key'  => 'titleUnderImage',
+			'type' => 'bool',
+		),
+		'player_below_excerpt' => array(
+			'key'  => 'playerBelowExcerpt',
+			'type' => 'bool',
+		),
+	);
+
+	/**
+	 * Episode list presenter instance.
+	 *
+	 * @var Episode_List_Presenter
+	 */
+	private $presenter;
+
+	/**
+	 * Initializes the episode list shortcode.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param Episode_List_Presenter $presenter Episode list presenter instance.
+	 */
+	public function __construct( $presenter ) {
+		$this->presenter = $presenter;
+	}
+
+	/**
+	 * Renders the episode list shortcode.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param array $params Shortcode attributes.
+	 *
+	 * @return string HTML output.
+	 */
+	public function shortcode( $params ) {
+		$defaults = array(
+			'podcast_id'           => '-1',
+			'posts_per_page'       => '0',
+			'order_by'             => 'date',
+			'order'                => 'desc',
+			'columns'              => '1',
+			'display_player'       => 'false',
+			'display_excerpt'      => 'false',
+			'display_title'        => 'true',
+			'display_image'        => 'true',
+			'image_size'           => 'full',
+			'title_size'           => '16',
+			'title_under_image'    => 'false',
+			'player_below_excerpt' => 'false',
+		);
+
+		$atts = shortcode_atts( $defaults, $params, 'ssp_episode_list' );
+
+		// Fallback: register the style if the block system hasn't done it (e.g. Classic Editor).
+		if ( ! wp_style_is( 'ssp-podcast-list', 'registered' ) ) {
+			wp_register_style( 'ssp-podcast-list', esc_url( SSP_PLUGIN_URL . 'assets/css/blocks/podcast-list.css' ), array(), SSP_VERSION );
+		}
+		wp_enqueue_style( 'ssp-podcast-list' );
+
+		$presenter_atts = $this->map_attributes( $atts );
+
+		return $this->presenter->render( $presenter_atts );
+	}
+
+	/**
+	 * Maps snake_case shortcode attributes to camelCase presenter attributes
+	 * with proper type casting.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param array $atts Parsed shortcode attributes.
+	 *
+	 * @return array Presenter-compatible attributes.
+	 */
+	private function map_attributes( $atts ) {
+		$mapped = array();
+
+		foreach ( self::ATTRIBUTE_MAP as $shortcode_key => $config ) {
+			if ( ! isset( $atts[ $shortcode_key ] ) ) {
+				continue;
+			}
+
+			$value                    = $atts[ $shortcode_key ];
+			$mapped[ $config['key'] ] = 'bool' === $config['type']
+				? filter_var( $value, FILTER_VALIDATE_BOOLEAN )
+				: $value;
+		}
+
+		return $mapped;
+	}
+}

--- a/php/config/settings/general.php
+++ b/php/config/settings/general.php
@@ -41,5 +41,16 @@ return array(
 			'type'        => 'text',
 			'default'     => ssp_series_slug(),
 		),
+		array(
+			'id'          => 'podcast_page_id',
+			'label'       => __( 'Podcast archive page', 'seriously-simple-podcasting' ),
+			'description' => sprintf(
+				/* translators: %s: podcast archive URL */
+				__( 'Select a page for your episodes list (%s). When set, you can customize the layout with the block editor or any page builder.', 'seriously-simple-podcasting' ),
+				'<a href="' . esc_url( get_post_type_archive_link( SSP_CPT_PODCAST ) ) . '" target="_blank">' . esc_html( get_post_type_archive_link( SSP_CPT_PODCAST ) ) . '</a>'
+			),
+			'type'        => 'single_select_page',
+			'default'     => '',
+		),
 	),
 );

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.14.4
+ * Version: 3.15.0-alpha
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.14.4' );
+define( 'SSP_VERSION', '3.15.0-alpha' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/src/components/EpisodeSyncStatus.js
+++ b/src/components/EpisodeSyncStatus.js
@@ -24,6 +24,14 @@ const EpisodeSyncStatus = () => {
 		try {
 			const updatedPost = await fetchPostData(currentPost);
 
+			if ( updatedPost ) {
+				// Some meta fields (e.g. podmotor_episode_id) are set server-side
+				// by Castos sync after save. The editor store still holds the
+				// pre-save value, so refresh it to prevent the next save from
+				// overwriting it via REST API.
+				refreshCastosMeta(updatedPost, currentPost);
+			}
+
 			if (updatedPost && updatedPost[ 'episode_data' ]) {
 				let syncStatus = updatedPost[ 'episode_data' ].syncStatus
 				if ( ! syncStatus ||  'none' === syncStatus.status ) {
@@ -40,6 +48,44 @@ const EpisodeSyncStatus = () => {
 		} catch (error) {
 			console.error('Error:', error)
 			return null
+		}
+	}
+
+	const refreshCastosMeta = (updatedPost, currentPost) => {
+		const castosMetaKeys = ['podmotor_episode_id'];
+		const meta = updatedPost.meta;
+		if ( ! meta ) {
+			return;
+		}
+
+		for ( const key of castosMetaKeys ) {
+			if ( ! ( key in meta ) ) {
+				continue;
+			}
+
+			// Update the hidden input in the metabox form.
+			const input = document.querySelector('input[name="' + key + '"]');
+			if ( input ) {
+				input.value = meta[key];
+			}
+		}
+
+		const existingRecord = wp.data.select('core').getEntityRecord(
+			'postType', currentPost.type, currentPost.id
+		);
+		if ( existingRecord ) {
+			const updatedMeta = {};
+			for ( const key of castosMetaKeys ) {
+				if ( key in meta ) {
+					updatedMeta[key] = meta[key];
+				}
+			}
+			wp.data.dispatch('core').receiveEntityRecords(
+				'postType', currentPost.type, [{
+					...existingRecord,
+					meta: { ...existingRecord.meta, ...updatedMeta },
+				}]
+			);
 		}
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,13 +19,15 @@ import EditPlaylistPlayer from "./components/EditPlaylistPlayer";
 
 /**
  * Standard Audio Player Block
+ * @deprecated Use 'seriously-simple-podcasting/castos-html-player' instead
  */
 registerBlockType('seriously-simple-podcasting/audio-player', {
-	title: __('Audio Player', 'seriously-simple-podcasting'),
+	title: __('Audio Player (deprecated)', 'seriously-simple-podcasting'),
 	icon: 'controls-volumeon',
 	category: 'layout',
 	supports: {
 		multiple: false,
+		inserter: false,
 	},
 	attributes: {
 		id: {
@@ -51,11 +53,12 @@ registerBlockType('seriously-simple-podcasting/audio-player', {
  * @deprecated Use 'seriously-simple-podcasting/castos-html-player' instead
  */
 registerBlockType('seriously-simple-podcasting/castos-player', {
-	title: __('Castos Player (OLD)', 'seriously-simple-podcasting'),
+	title: __('Castos Player (deprecated)', 'seriously-simple-podcasting'),
 	icon: 'controls-volumeon',
 	category: 'layout',
 	supports: {
 		multiple: false,
+		inserter: false,
 	},
 	attributes: {
 		id: {

--- a/templates/archive-page-notice.php
+++ b/templates/archive-page-notice.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Archive page upgrade notice template.
+ *
+ * @var string $setup_url   URL to set up the archive page.
+ * @var string $dismiss_url URL to dismiss the notice.
+ * @var string $archive_url Podcast archive URL.
+ */
+?>
+
+<div class="notice notice-info is-dismissible">
+	<p>
+		<?php
+		printf(
+			/* translators: %s: podcast archive URL */
+			esc_html__( 'You can now customize your episodes page (%s) with the block editor or any page builder.', 'seriously-simple-podcasting' ),
+			'<a href="' . esc_url( $archive_url ) . '" target="_blank">' . esc_html( $archive_url ) . '</a>'
+		);
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_url( $setup_url ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Set up now', 'seriously-simple-podcasting' ); ?>
+		</a>
+		<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
+			<?php esc_html_e( 'Dismiss', 'seriously-simple-podcasting' ); ?>
+		</a>
+	</p>
+</div>

--- a/tests/WPUnit/ArchivePageTest.php
+++ b/tests/WPUnit/ArchivePageTest.php
@@ -93,7 +93,7 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 			'post_status'  => 'publish',
 			'post_name'    => 'ssp-podcast-archive',
 			'post_title'   => 'Podcast',
-			'post_content' => '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->',
+			'post_content' => '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"24"} /-->',
 		] );
 
 		// Trash it — WordPress mangles slug to ssp-podcast-archive__trashed.
@@ -179,7 +179,7 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 		$page    = get_post( $page_id );
 
 		$this->assertStringContainsString(
-			'<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->',
+			'<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"24"} /-->',
 			$page->post_content
 		);
 	}
@@ -195,6 +195,36 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( 'page', $page->post_type );
 		$this->assertEquals( 'publish', $page->post_status );
 		$this->assertEquals( 'closed', $page->comment_status );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::get_podcast_archive_page_content()
+	 */
+	public function testPageUsesShortcodeWhenBlockEditorDisabled()
+	{
+		// Simulate Classic Editor — disable block editor for pages.
+		add_filter( 'use_block_editor_for_post_type', '__return_false' );
+
+		$page_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+		$page    = get_post( $page_id );
+
+		$this->assertStringContainsString( '[ssp_episode_list', $page->post_content );
+		$this->assertStringContainsString( 'display_player="true"', $page->post_content );
+		$this->assertStringNotContainsString( '<!-- wp:', $page->post_content );
+
+		remove_filter( 'use_block_editor_for_post_type', '__return_false' );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::get_podcast_archive_page_content()
+	 */
+	public function testPageUsesBlockWhenBlockEditorEnabled()
+	{
+		$page_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+		$page    = get_post( $page_id );
+
+		$this->assertStringContainsString( '<!-- wp:seriously-simple-podcasting/podcast-list', $page->post_content );
+		$this->assertStringNotContainsString( '[ssp_episode_list', $page->post_content );
 	}
 
 	// =========================================================================

--- a/tests/WPUnit/ArchivePageTest.php
+++ b/tests/WPUnit/ArchivePageTest.php
@@ -1,0 +1,432 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Handlers\Archive_Page_Handler;
+
+class ArchivePageTest extends \Codeception\TestCase\WPTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+	}
+
+	protected function tearDown(): void
+	{
+		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+		parent::tearDown();
+	}
+
+	/**
+	 * Returns the Archive_Page_Handler instance from the plugin container.
+	 *
+	 * @return \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler
+	 */
+	protected function get_archive_page_handler() {
+		return ssp_app()->get_service( 'archive_page_handler' );
+	}
+
+	// =========================================================================
+	// Archive_Page_Handler::create_podcast_archive_page()
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::create_podcast_archive_page()
+	 */
+	public function testCreatesNewPageWhenNoneExists()
+	{
+		$page_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+
+		$this->assertIsInt( $page_id );
+		$this->assertGreaterThan( 0, $page_id );
+
+		$page = get_post( $page_id );
+		$this->assertNotNull( $page );
+		$this->assertEquals( $page_id, (int) get_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID ) );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::create_podcast_archive_page()
+	 */
+	public function testReturnsExistingPageWhenOptionSet()
+	{
+		$existing_page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_name'   => 'podcast',
+			'post_title'  => 'Podcast',
+		] );
+
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $existing_page_id );
+
+		$returned_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+
+		$this->assertEquals( $existing_page_id, $returned_id );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::create_podcast_archive_page()
+	 */
+	public function testReusesExistingPageBySlug()
+	{
+		$existing_page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_name'   => 'ssp-podcast-archive',
+			'post_title'  => 'Podcast',
+		] );
+
+		$returned_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+
+		$this->assertEquals( $existing_page_id, $returned_id );
+		$this->assertEquals( $existing_page_id, (int) get_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID ) );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::create_podcast_archive_page()
+	 */
+	public function testRestoresPageFromTrash()
+	{
+		$page_id = $this->factory()->post->create( [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_name'    => 'ssp-podcast-archive',
+			'post_title'   => 'Podcast',
+			'post_content' => '<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->',
+		] );
+
+		// Trash it — WordPress mangles slug to ssp-podcast-archive__trashed.
+		wp_trash_post( $page_id );
+
+		$returned_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+
+		$this->assertEquals( $page_id, $returned_id );
+		$this->assertEquals( 'publish', get_post_status( $returned_id ) );
+		$this->assertEquals( $page_id, (int) get_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID ) );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::create_podcast_archive_page()
+	 */
+	public function testRespectsStaleOptionValue()
+	{
+		$trashed_page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_name'   => 'some-page',
+			'post_title'  => 'Some Page',
+		] );
+		wp_trash_post( $trashed_page_id );
+
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $trashed_page_id );
+
+		$returned_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+
+		$this->assertEquals( 0, $returned_id, 'Should not override a stale option — the user had a page.' );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::setup_podcast_archive_page()
+	 */
+	public function testSetupBypassesStaleOptionValue()
+	{
+		$trashed_page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_name'   => 'some-page',
+			'post_title'  => 'Some Page',
+		] );
+		wp_trash_post( $trashed_page_id );
+
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $trashed_page_id );
+
+		$returned_id = $this->get_archive_page_handler()->setup_podcast_archive_page();
+
+		$this->assertGreaterThan( 0, $returned_id );
+		$this->assertNotEquals( 'trash', get_post_status( $returned_id ) );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::setup_podcast_archive_page()
+	 */
+	public function testSetupRestoresOptionOnFailure()
+	{
+		$stale_page_id = 999999;
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $stale_page_id );
+
+		// Block page creation by pre-occupying the slug with a non-page post type.
+		// setup_podcast_archive_page() will clear the option, fail to find a page by slug,
+		// then create_page() should succeed — so we test the restore by hooking wp_insert_post.
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$returned_id = $this->get_archive_page_handler()->setup_podcast_archive_page();
+
+		remove_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$this->assertEquals( 0, $returned_id );
+		$this->assertEquals( $stale_page_id, (int) get_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID ),
+			'Should restore the old option value when creation fails.'
+		);
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::create_podcast_archive_page()
+	 */
+	public function testPageHasCorrectContent()
+	{
+		$page_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+		$page    = get_post( $page_id );
+
+		$this->assertStringContainsString(
+			'<!-- wp:seriously-simple-podcasting/podcast-list {"featuredImage":false,"excerpt":true,"player":true,"titleSize":"48"} /-->',
+			$page->post_content
+		);
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::create_podcast_archive_page()
+	 */
+	public function testPageHasCorrectProperties()
+	{
+		$page_id = $this->get_archive_page_handler()->create_podcast_archive_page();
+		$page    = get_post( $page_id );
+
+		$this->assertEquals( 'page', $page->post_type );
+		$this->assertEquals( 'publish', $page->post_status );
+		$this->assertEquals( 'closed', $page->comment_status );
+	}
+
+	// =========================================================================
+	// activate() — fresh install page creation
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Controllers\App_Controller::activate()
+	 */
+	public function testActivateCreatesPageOnFreshInstall()
+	{
+		// Simulate fresh install — no ssp_version option.
+		delete_option( 'ssp_version' );
+
+		ssp_app()->activate();
+
+		$page_id = (int) get_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+		$this->assertGreaterThan( 0, $page_id );
+
+		$page = get_post( $page_id );
+		$this->assertNotNull( $page );
+		$this->assertEquals( 'page', $page->post_type );
+		$this->assertEquals( 'publish', $page->post_status );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Controllers\App_Controller::activate()
+	 */
+	public function testActivateDoesNotCreatePageOnUpgrade()
+	{
+		// Simulate upgrade — ssp_version exists.
+		update_option( 'ssp_version', '3.14.0' );
+
+		ssp_app()->activate();
+
+		$page_id = get_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+		$this->assertEmpty( $page_id );
+	}
+
+	// =========================================================================
+	// Settings UI
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Renderers\Settings_Renderer::render_single_select_page()
+	 */
+	public function testSettingsRendererOutputsPageDropdown()
+	{
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_title'  => 'My Podcast Page',
+		] );
+
+		$renderer = \SeriouslySimplePodcasting\Renderers\Settings_Renderer::instance();
+		$field    = [
+			'id'      => 'podcast_page_id',
+			'type'    => 'single_select_page',
+			'default' => '',
+		];
+
+		$html = $renderer->render_field( $field, $page_id, Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+
+		$this->assertStringContainsString( '<select', $html );
+		$this->assertStringContainsString( 'js-ssp-select2', $html );
+		$this->assertStringContainsString( 'My Podcast Page (ID: ' . $page_id . ')', $html );
+		$this->assertStringContainsString( 'selected', $html );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Renderers\Settings_Renderer::render_single_select_page()
+	 */
+	public function testSettingsRendererShowsNoneOptionWhenNoPageSelected()
+	{
+		// wp_dropdown_pages() returns empty when no pages exist, so create one.
+		$this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_title'  => 'Some Page',
+		] );
+
+		$renderer = \SeriouslySimplePodcasting\Renderers\Settings_Renderer::instance();
+		$field    = [
+			'id'      => 'podcast_page_id',
+			'type'    => 'single_select_page',
+			'default' => '',
+		];
+
+		$html = $renderer->render_field( $field, '', Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+
+		$this->assertStringContainsString( '<select', $html );
+		$this->assertStringContainsString( 'Select a page', $html );
+	}
+
+	public function testPodcastPageIdFieldExistsInGeneralSettings()
+	{
+		$settings = ssp_config( 'settings/general', array( 'post_type_options' => array() ) );
+		$field_ids = array_column( $settings['fields'], 'id' );
+
+		$this->assertContains( 'podcast_page_id', $field_ids );
+	}
+
+	public function testPodcastPageIdFieldIsSingleSelectPage()
+	{
+		$settings = ssp_config( 'settings/general', array( 'post_type_options' => array() ) );
+		$fields   = array_column( $settings['fields'], 'type', 'id' );
+
+		$this->assertEquals( 'single_select_page', $fields['podcast_page_id'] );
+	}
+
+	// =========================================================================
+	// Routing — has_archive is always true
+	// =========================================================================
+
+	/**
+	 * has_archive is always true regardless of page assignment.
+	 * The archive URL is controlled by the rewrite slug, and template_include
+	 * serves the page content when a page is assigned.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Handlers\CPT_Podcast_Handler::register_post_type()
+	 */
+	public function testHasArchiveIsAlwaysTrue()
+	{
+		// With page assigned.
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_name'   => 'ssp-podcast-archive',
+		] );
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
+
+		$handler = ssp_app()->get_service( 'cpt_podcast_handler' );
+		$handler->register_post_type();
+
+		$this->assertTrue( get_post_type_object( SSP_CPT_PODCAST )->has_archive );
+
+		// Without page assigned.
+		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+		$handler->register_post_type();
+
+		$this->assertTrue( get_post_type_object( SSP_CPT_PODCAST )->has_archive );
+	}
+
+	// =========================================================================
+	// Template override: serve page instead of CPT archive
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Controllers\Frontend_Controller::maybe_serve_archive_page()
+	 */
+	public function testServeArchivePageReturnsOriginalTemplateWhenNoPageAssigned()
+	{
+		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+
+		$this->go_to( home_url( '/podcast/' ) );
+
+		// The filter is already registered by the plugin bootstrap.
+		$result = apply_filters( 'template_include', '/some/archive-podcast.php' );
+
+		$this->assertEquals( '/some/archive-podcast.php', $result );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Controllers\Frontend_Controller::maybe_serve_archive_page()
+	 */
+	public function testServeArchivePageReplacesQueryWhenPageAssigned()
+	{
+		global $wpdb;
+
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_title'  => 'Podcast',
+		] );
+
+		$wpdb->update( $wpdb->posts, [ 'post_name' => 'podcast-archive-test' ], [ 'ID' => $page_id ] );
+		clean_post_cache( $page_id );
+
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
+
+		// Use query string to simulate CPT archive (rewrite rules may not be loaded in tests).
+		$this->go_to( home_url( '?post_type=podcast' ) );
+		$this->assertTrue( is_post_type_archive( SSP_CPT_PODCAST ), 'Should be podcast archive' );
+
+		apply_filters( 'template_include', '/some/archive-podcast.php' );
+
+		global $wp_query;
+		$this->assertTrue( $wp_query->is_page );
+		$this->assertFalse( $wp_query->is_archive );
+		$this->assertEquals( $page_id, $wp_query->queried_object_id );
+	}
+
+	// =========================================================================
+	// Admin notice for existing installs
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler::maybe_show_archive_page_notice()
+	 */
+	public function testArchivePageNoticeNotShownWhenDismissed()
+	{
+		update_option( Archive_Page_Handler::OPTION_NOTICE_DISMISSED, true );
+		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+
+		$handler = new \SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler( $this->get_archive_page_handler(), new \SeriouslySimplePodcasting\Renderers\Renderer() );
+
+		ob_start();
+		$handler->maybe_show_archive_page_notice();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler::maybe_show_archive_page_notice()
+	 */
+	public function testArchivePageNoticeNotShownWhenPageAssigned()
+	{
+		delete_option( Archive_Page_Handler::OPTION_NOTICE_DISMISSED );
+
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		] );
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
+
+		$handler = new \SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler( $this->get_archive_page_handler(), new \SeriouslySimplePodcasting\Renderers\Renderer() );
+
+		ob_start();
+		$handler->maybe_show_archive_page_notice();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+}

--- a/tests/WPUnit/ArchivePageTest.php
+++ b/tests/WPUnit/ArchivePageTest.php
@@ -428,6 +428,7 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 	{
 		update_option( Archive_Page_Handler::OPTION_NOTICE_DISMISSED, true );
 		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+		set_current_screen( 'edit-podcast' );
 
 		$handler = new \SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler( $this->get_archive_page_handler(), new \SeriouslySimplePodcasting\Renderers\Renderer() );
 
@@ -444,6 +445,7 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 	public function testArchivePageNoticeNotShownWhenPageAssigned()
 	{
 		delete_option( Archive_Page_Handler::OPTION_NOTICE_DISMISSED );
+		set_current_screen( 'edit-podcast' );
 
 		$page_id = $this->factory()->post->create( [
 			'post_type'   => 'page',

--- a/tests/WPUnit/EpisodeListShortcodeTest.php
+++ b/tests/WPUnit/EpisodeListShortcodeTest.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Controllers\Shortcodes_Controller;
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
+use SeriouslySimplePodcasting\ShortCodes\Episode_List;
+
+/**
+ * Tests for the [ssp_episode_list] shortcode.
+ *
+ * Focuses on shortcode-specific behavior: registration, attribute mapping
+ * (snake_case → camelCase), boolean casting, and CSS enqueuing.
+ * HTML output correctness is already covered by PodcastListBlockTest
+ * since both consumers share Episode_List_Presenter.
+ *
+ * @package SeriouslySimplePodcasting\Tests
+ * @since 3.15.0
+ */
+class EpisodeListShortcodeTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var Episode_List_Presenter
+	 */
+	protected $presenter;
+
+	/**
+	 * @var Episode_List
+	 */
+	protected $shortcode;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->presenter = new Episode_List_Presenter(
+			ssp_get_service( 'episode_repository' ),
+			ssp_get_service( 'players_controller' ),
+			ssp_get_service( 'renderer' )
+		);
+
+		$this->shortcode = new Episode_List( $this->presenter );
+	}
+
+	/**
+	 * Helper: create a published podcast episode with an audio file.
+	 */
+	protected function create_episode( $title = 'Test Episode', $series = array() ) {
+		$episode_id = $this->factory()->post->create( array(
+			'post_type'    => 'podcast',
+			'post_status'  => 'publish',
+			'post_title'   => $title,
+			'post_excerpt' => 'Excerpt for ' . $title,
+		) );
+
+		update_post_meta( $episode_id, 'audio_file', 'https://example.com/episode.mp3' );
+
+		if ( ! empty( $series ) ) {
+			wp_set_post_terms( $episode_id, $series, 'series' );
+		}
+
+		return $episode_id;
+	}
+
+	// =========================================================================
+	// Registration
+	// =========================================================================
+
+	// =========================================================================
+	// Attribute mapping
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testDefaultAttributesProduceValidOutput()
+	{
+		$this->create_episode( 'Default Attrs Episode' );
+
+		$output = $this->shortcode->shortcode( array() );
+
+		$this->assertStringContainsString( 'ssp-podcast-list', $output );
+		$this->assertStringContainsString( 'Default Attrs Episode', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testPodcastIdAttributeFiltersSeries()
+	{
+		$series = $this->factory()->term->create( array(
+			'taxonomy' => 'series',
+			'name'     => 'Filtered Series',
+		) );
+
+		$this->create_episode( 'In Series', array( $series ) );
+		$this->create_episode( 'Not In Series' );
+
+		$output = $this->shortcode->shortcode( array( 'podcast_id' => $series ) );
+
+		$this->assertStringContainsString( 'In Series', $output );
+		$this->assertStringNotContainsString( 'Not In Series', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testBooleanAttributesCastFromStrings()
+	{
+		$this->create_episode( 'Bool Test Episode' );
+
+		// display_title="false" should hide titles
+		$output = $this->shortcode->shortcode( array(
+			'display_title' => 'false',
+		) );
+
+		$this->assertStringNotContainsString( 'entry-title-link', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testBooleanAttributesAcceptNumericStrings()
+	{
+		$this->create_episode( 'Numeric Bool Episode' );
+
+		// display_title="1" should show titles
+		$output_with = $this->shortcode->shortcode( array(
+			'display_title' => '1',
+		) );
+		$this->assertStringContainsString( 'entry-title-link', $output_with );
+
+		// display_title="0" should hide titles
+		$output_without = $this->shortcode->shortcode( array(
+			'display_title' => '0',
+		) );
+		$this->assertStringNotContainsString( 'entry-title-link', $output_without );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testColumnsAttribute()
+	{
+		$this->create_episode( 'Columns Test' );
+
+		$output = $this->shortcode->shortcode( array( 'columns' => '3' ) );
+
+		$this->assertStringContainsString( 'ssp-podcast-list', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testOrderByAttribute()
+	{
+		$this->create_episode( 'Episode A' );
+		$this->create_episode( 'Episode B' );
+
+		$output_asc = $this->shortcode->shortcode( array(
+			'order_by' => 'title',
+			'order'    => 'asc',
+		) );
+
+		$pos_a = strpos( $output_asc, 'Episode A' );
+		$pos_b = strpos( $output_asc, 'Episode B' );
+
+		$this->assertNotFalse( $pos_a );
+		$this->assertNotFalse( $pos_b );
+		$this->assertLessThan( $pos_b, $pos_a, 'Episode A should appear before Episode B in ASC title order' );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testPostsPerPageAttribute()
+	{
+		$this->create_episode( 'Episode 1' );
+		$this->create_episode( 'Episode 2' );
+		$this->create_episode( 'Episode 3' );
+
+		$output = $this->shortcode->shortcode( array( 'posts_per_page' => '2' ) );
+
+		// Should contain pagination since 3 episodes > 2 per page
+		$this->assertStringContainsString( 'ssp-podcast-list__pagination', $output );
+	}
+
+	// =========================================================================
+	// CSS enqueuing
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testCssEnqueuedOnRender()
+	{
+		$this->create_episode( 'CSS Test Episode' );
+
+		// Register the style first (normally done by the block)
+		wp_register_style( 'ssp-podcast-list', 'https://example.com/podcast-list.css' );
+
+		$this->shortcode->shortcode( array() );
+
+		$this->assertTrue( wp_style_is( 'ssp-podcast-list', 'enqueued' ) );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testCssFallbackRegistrationWithoutBlock()
+	{
+		$this->create_episode( 'CSS Fallback Episode' );
+
+		// Deregister to simulate Classic Editor (block system not loaded).
+		wp_deregister_style( 'ssp-podcast-list' );
+
+		$this->shortcode->shortcode( array() );
+
+		$this->assertTrue( wp_style_is( 'ssp-podcast-list', 'registered' ), 'Style should be registered by fallback' );
+		$this->assertTrue( wp_style_is( 'ssp-podcast-list', 'enqueued' ), 'Style should be enqueued after fallback registration' );
+	}
+
+	// =========================================================================
+	// Output parity with block
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testShortcodeOutputMatchesPresenterOutput()
+	{
+		$this->create_episode( 'Parity Test Episode' );
+
+		$shortcode_output = $this->shortcode->shortcode( array() );
+
+		// Same defaults via presenter directly
+		$presenter_output = $this->presenter->render( array(
+			'selectedPodcast'    => '-1',
+			'postsPerPage'       => '0',
+			'orderBy'            => 'date',
+			'order'              => 'desc',
+			'columnsPerRow'      => '1',
+			'player'             => false,
+			'excerpt'            => false,
+			'showTitle'          => true,
+			'featuredImage'      => true,
+			'featuredImageSize'  => 'full',
+			'titleSize'          => '16',
+			'titleUnderImage'    => false,
+			'playerBelowExcerpt' => false,
+		) );
+
+		$this->assertEquals( $presenter_output, $shortcode_output );
+	}
+
+	// =========================================================================
+	// Edge cases
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testEmptyEpisodesReturnsNotFoundMessage()
+	{
+		$output = $this->shortcode->shortcode( array() );
+
+		$this->assertStringContainsString( 'Sorry, episodes not found', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\ShortCodes\Episode_List::shortcode()
+	 */
+	public function testUnknownAttributesAreIgnored()
+	{
+		$this->create_episode( 'Unknown Attrs Episode' );
+
+		$output = $this->shortcode->shortcode( array(
+			'nonexistent_attr' => 'value',
+			'display_title'    => 'true',
+		) );
+
+		$this->assertStringContainsString( 'ssp-podcast-list', $output );
+		$this->assertStringContainsString( 'Unknown Attrs Episode', $output );
+	}
+
+	// =========================================================================
+	// Registration (last — fires init which triggers block re-registration notices)
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Controllers\Shortcodes_Controller::register_shortcodes()
+	 */
+	public function testShortcodeIsRegistered()
+	{
+		$this->setExpectedIncorrectUsage( 'WP_Block_Type_Registry::register' );
+		$this->setExpectedIncorrectUsage( 'WP_Block_Bindings_Registry::register' );
+
+		$controller = new Shortcodes_Controller(
+			dirname( dirname( __DIR__ ) ) . '/seriously-simple-podcasting.php',
+			'3.15.0',
+			$this->presenter
+		);
+
+		@do_action( 'init' );
+
+		global $shortcode_tags;
+		$this->assertArrayHasKey( 'ssp_episode_list', $shortcode_tags );
+	}
+}

--- a/tests/WPUnit/PodcastListBlockTest.php
+++ b/tests/WPUnit/PodcastListBlockTest.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
+
+/**
+ * Tests for Episode_List_Presenter — the shared rendering service
+ * used by the podcast-list block and [ssp_episode_list] shortcode.
+ *
+ * @package SeriouslySimplePodcasting\Tests
+ * @since 3.15.0
+ */
+class PodcastListBlockTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var Episode_List_Presenter
+	 */
+	protected $renderer;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->renderer = new Episode_List_Presenter(
+			ssp_get_service( 'episode_repository' ),
+			ssp_get_service( 'players_controller' ),
+			ssp_get_service( 'renderer' )
+		);
+	}
+
+	/**
+	 * Helper: create a published podcast episode with an audio file.
+	 *
+	 * @param string $title   Episode title.
+	 * @param array  $series  Optional term IDs to assign.
+	 *
+	 * @return int Post ID.
+	 */
+	protected function create_episode( $title = 'Test Episode', $series = array() ) {
+		$episode_id = $this->factory()->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => $title,
+			'post_excerpt' => 'Excerpt for ' . $title,
+		) );
+
+		update_post_meta( $episode_id, 'audio_file', 'https://example.com/episode.mp3' );
+
+		if ( ! empty( $series ) ) {
+			wp_set_post_terms( $episode_id, $series, 'series' );
+		}
+
+		return $episode_id;
+	}
+
+	/**
+	 * Returns default block attributes matching the registered defaults.
+	 *
+	 * @param array $overrides Attributes to override.
+	 *
+	 * @return array
+	 */
+	protected function get_default_attributes( $overrides = array() ) {
+		return array_merge( array(
+			'showTitle'          => true,
+			'featuredImage'      => true,
+			'featuredImageSize'  => 'full',
+			'excerpt'            => false,
+			'player'             => false,
+			'playerBelowExcerpt' => false,
+			'selectedPodcast'    => '-1',
+			'postsPerPage'       => 0,
+			'orderBy'            => 'date',
+			'order'              => 'desc',
+			'columnsPerRow'      => 1,
+			'titleSize'          => 16,
+			'titleUnderImage'    => false,
+		), $overrides );
+	}
+
+	// =========================================================================
+	// Render callback — HTML structure
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOutputContainsListWrapper()
+	{
+		$this->create_episode( 'Wrapper Test' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes()
+		);
+
+		$this->assertStringContainsString( 'ssp-podcast-list', $output );
+		$this->assertStringContainsString( 'ssp-podcast-list__articles', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOutputContainsEpisodeArticle()
+	{
+		$episode_id = $this->create_episode( 'Article Test' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes()
+		);
+
+		$this->assertStringContainsString( '<article', $output );
+		$this->assertStringContainsString( 'podcast-' . $episode_id, $output );
+		$this->assertStringContainsString( 'Article Test', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOutputContainsTitleLink()
+	{
+		$episode_id = $this->create_episode( 'Title Link Test' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'showTitle' => true ) )
+		);
+
+		$this->assertStringContainsString( 'entry-title-link', $output );
+		$this->assertStringContainsString( 'Title Link Test', $output );
+		$this->assertStringContainsString( get_permalink( $episode_id ), $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOutputHidesTitleWhenDisabled()
+	{
+		$this->create_episode( 'Hidden Title' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'showTitle' => false ) )
+		);
+
+		$this->assertStringNotContainsString( 'entry-title-link', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOutputContainsExcerptWhenEnabled()
+	{
+		$this->create_episode( 'Excerpt Test' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'excerpt' => true ) )
+		);
+
+		$this->assertStringContainsString( 'Excerpt for Excerpt Test', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOutputHidesExcerptWhenDisabled()
+	{
+		$this->create_episode( 'No Excerpt' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'excerpt' => false ) )
+		);
+
+		$this->assertStringNotContainsString( 'Excerpt for No Excerpt', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOutputContainsCssVariables()
+	{
+		$this->create_episode( 'CSS Vars Test' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'titleSize' => 48, 'columnsPerRow' => 2 ) )
+		);
+
+		$this->assertStringContainsString( '--ssp-podcast-list-title-size: 48px', $output );
+		$this->assertStringContainsString( '--ssp-podcast-list-cols: 2', $output );
+	}
+
+	// =========================================================================
+	// Query building — series filtering
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderShowsAllEpisodesWhenSelectedPodcastIsMinusOne()
+	{
+		$series_a = $this->factory()->term->create( array( 'taxonomy' => 'series', 'name' => 'Series A' ) );
+		$series_b = $this->factory()->term->create( array( 'taxonomy' => 'series', 'name' => 'Series B' ) );
+
+		$this->create_episode( 'Episode A', array( $series_a ) );
+		$this->create_episode( 'Episode B', array( $series_b ) );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'selectedPodcast' => '-1' ) )
+		);
+
+		$this->assertStringContainsString( 'Episode A', $output );
+		$this->assertStringContainsString( 'Episode B', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderFiltersBySeriesWhenSelected()
+	{
+		$series_a = $this->factory()->term->create( array( 'taxonomy' => 'series', 'name' => 'Series A' ) );
+		$series_b = $this->factory()->term->create( array( 'taxonomy' => 'series', 'name' => 'Series B' ) );
+
+		$this->create_episode( 'Episode A', array( $series_a ) );
+		$this->create_episode( 'Episode B', array( $series_b ) );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'selectedPodcast' => strval( $series_a ) ) )
+		);
+
+		$this->assertStringContainsString( 'Episode A', $output );
+		$this->assertStringNotContainsString( 'Episode B', $output );
+	}
+
+	// =========================================================================
+	// Query building — ordering
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOrdersByDateDesc()
+	{
+		$this->create_episode( 'Older Episode' );
+		sleep( 1 ); // Ensure different post_date.
+		$this->create_episode( 'Newer Episode' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'orderBy' => 'date', 'order' => 'desc' ) )
+		);
+
+		$pos_newer = strpos( $output, 'Newer Episode' );
+		$pos_older = strpos( $output, 'Older Episode' );
+
+		$this->assertLessThan( $pos_older, $pos_newer, 'Newer episode should appear before older in desc order.' );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderOrdersByTitleAsc()
+	{
+		$this->create_episode( 'Banana Episode' );
+		$this->create_episode( 'Apple Episode' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'orderBy' => 'title', 'order' => 'asc' ) )
+		);
+
+		$pos_apple  = strpos( $output, 'Apple Episode' );
+		$pos_banana = strpos( $output, 'Banana Episode' );
+
+		$this->assertLessThan( $pos_banana, $pos_apple, 'Apple should appear before Banana in asc title order.' );
+	}
+
+	// =========================================================================
+	// Query building — pagination
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderShowsPaginationWhenMoreEpisodesThanPerPage()
+	{
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$this->create_episode( 'Episode ' . $i );
+		}
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'postsPerPage' => '2' ) )
+		);
+
+		$this->assertStringContainsString( 'ssp-podcast-list__pagination', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderShowsEmptyPaginationWhenAllEpisodesFit()
+	{
+		$this->create_episode( 'Only Episode' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'postsPerPage' => '10' ) )
+		);
+
+		// Pagination wrapper is always rendered, but empty when all episodes fit on one page.
+		$this->assertStringContainsString( 'ssp-podcast-list__pagination', $output );
+		$this->assertStringNotContainsString( 'class="next', $output );
+		$this->assertStringNotContainsString( 'class="prev', $output );
+	}
+
+	// =========================================================================
+	// Query building — audio_file meta query
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderExcludesEpisodesWithoutAudioFile()
+	{
+		$this->create_episode( 'Has Audio' );
+
+		// Create episode without audio_file.
+		$no_audio = $this->factory()->post->create( array(
+			'post_type'   => 'podcast',
+			'post_status' => 'publish',
+			'post_title'  => 'No Audio',
+		) );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes()
+		);
+
+		$this->assertStringContainsString( 'Has Audio', $output );
+		$this->assertStringNotContainsString( 'No Audio', $output );
+	}
+
+	// =========================================================================
+	// Edge cases
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderShowsEmptyMessageWhenNoEpisodes()
+	{
+		$output = $this->renderer->render(
+			$this->get_default_attributes()
+		);
+
+		$this->assertStringContainsString( 'Sorry, episodes not found', $output );
+		$this->assertStringNotContainsString( 'ssp-podcast-list__articles', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderHandlesInvalidSeriesId()
+	{
+		$this->create_episode( 'Valid Episode' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'selectedPodcast' => '999999' ) )
+		);
+
+		// Invalid series — no episodes should match.
+		$this->assertStringNotContainsString( 'Valid Episode', $output );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter::render()
+	 */
+	public function testRenderHandlesInvalidOrderBy()
+	{
+		$this->create_episode( 'Fallback Order Test' );
+
+		$output = $this->renderer->render(
+			$this->get_default_attributes( array( 'orderBy' => 'invalid_column' ) )
+		);
+
+		// Should fall back to 'date' ordering and still render.
+		$this->assertStringContainsString( 'Fallback Order Test', $output );
+	}
+}

--- a/tests/WPUnit/PodcastListTest.php
+++ b/tests/WPUnit/PodcastListTest.php
@@ -3,6 +3,7 @@
 namespace Tests\WPUnit;
 
 use SeriouslySimplePodcasting\Controllers\Shortcodes_Controller;
+use SeriouslySimplePodcasting\Presenters\Episode_List_Presenter;
 use SeriouslySimplePodcasting\ShortCodes\Podcast_List;
 
 class PodcastListTest extends \Codeception\TestCase\WPTestCase
@@ -17,9 +18,11 @@ class PodcastListTest extends \Codeception\TestCase\WPTestCase
         parent::setUp();
 
         // Initialize the shortcodes controller
+        $episode_list_presenter = $this->createMock(Episode_List_Presenter::class);
         $this->shortcodes_controller = new Shortcodes_Controller(
             dirname(dirname(__DIR__)) . '/seriously-simple-podcasting.php',
-            '3.13.0'
+            '3.13.0',
+            $episode_list_presenter
         );
     }
 

--- a/tests/WPUnit/SSPPodcastsBlockTest.php
+++ b/tests/WPUnit/SSPPodcastsBlockTest.php
@@ -51,12 +51,16 @@ class SSPPodcastsBlockTest extends \Codeception\TestCase\WPTestCase
         $this->players_controller = ssp_get_service('players_controller');
         $this->renderer = ssp_get_service('renderer');
 
-        // Initialize the Castos_Blocks class
-        $this->castos_blocks = new Castos_Blocks(
-            $this->admin_notices_handler,
+        $episode_list_renderer = new \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter(
             $this->episode_repository,
             $this->players_controller,
             $this->renderer
+        );
+
+        // Initialize the Castos_Blocks class
+        $this->castos_blocks = new Castos_Blocks(
+            $this->admin_notices_handler,
+            $episode_list_renderer
         );
     }
 

--- a/tests/WPUnit/SSPPodcastsBlockTest.php
+++ b/tests/WPUnit/SSPPodcastsBlockTest.php
@@ -51,7 +51,7 @@ class SSPPodcastsBlockTest extends \Codeception\TestCase\WPTestCase
         $this->players_controller = ssp_get_service('players_controller');
         $this->renderer = ssp_get_service('renderer');
 
-        $episode_list_renderer = new \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter(
+        $episode_list_presenter = new \SeriouslySimplePodcasting\Presenters\Episode_List_Presenter(
             $this->episode_repository,
             $this->players_controller,
             $this->renderer
@@ -60,7 +60,7 @@ class SSPPodcastsBlockTest extends \Codeception\TestCase\WPTestCase
         // Initialize the Castos_Blocks class
         $this->castos_blocks = new Castos_Blocks(
             $this->admin_notices_handler,
-            $episode_list_renderer
+            $episode_list_presenter
         );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose a custom podcast archive page with an admin notice to set up or dismiss it
  * Episode list shortcode and Podcast List block: filtering, sorting, pagination, and shared podcast-list styles
  * New Playlist Player and Castos HTML Player blocks; editor enqueues podcast-list styles
  * Editor now refreshes Castos meta after saving a post

* **Deprecated**
  * Legacy audio/Castos player blocks marked “(deprecated)” and insertion disabled

* **Tests**
  * Added comprehensive tests covering archive page and episode list flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->