### PR TITLE
Fix /podcast/ rendering on block themes #831

### DIFF
--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -132,11 +132,12 @@ class Frontend_Controller {
 
 		add_filter( 'feed_content_type', array( $this, 'feed_content_type' ), 10, 2 );
 
-		// When a podcast archive page is assigned, serve the page instead of the CPT archive template.
-		add_filter( 'template_include', array( $this, 'maybe_serve_archive_page' ), 99 );
-
 		// Redirect the archive page's own URL to the podcast archive URL.
-		add_action( 'template_redirect', array( $this, 'redirect_archive_page_to_podcast_url' ) );
+		add_action( 'template_redirect', array( $this, 'maybe_redirect_archive_page_to_podcast_url' ) );
+
+		// When a podcast archive page is assigned, swap the main query so WP's
+		// natural template dispatch picks the page template instead of the CPT archive.
+		add_action( 'template_redirect', array( $this, 'maybe_serve_archive_page' ) );
 
 		// Flush rewrite rules when the podcast archive page setting changes.
 		add_action( 'update_option_' . Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, 'flush_rewrite_rules' );
@@ -145,10 +146,6 @@ class Frontend_Controller {
 		add_action( 'plugins_loaded', array( $this, 'load_localisation' ) );
 
 		add_filter( 'archive_template_hierarchy', array( $this, 'fix_template_hierarchy' ) );
-
-		// When a podcast archive page is assigned, redirect block/classic template
-		// resolution to the page hierarchy so the page's blocks render at /podcast/.
-		add_filter( 'archive_template_hierarchy', array( $this, 'maybe_swap_archive_hierarchy' ) );
 	}
 
 	/**
@@ -651,28 +648,17 @@ class Frontend_Controller {
 	}
 
 	/**
-	 * @see Archive_Page_Handler::serve_archive_page()
+	 * @see Archive_Page_Handler::maybe_serve_archive_page()
 	 */
-	public function maybe_serve_archive_page( $template ) {
-		if ( ! is_post_type_archive( SSP_CPT_PODCAST ) ) {
-			return $template;
-		}
-
-		return $this->archive_page_handler->serve_archive_page( $template );
+	public function maybe_serve_archive_page() {
+		$this->archive_page_handler->maybe_serve_archive_page();
 	}
 
 	/**
-	 * @see Archive_Page_Handler::redirect_archive_page_to_podcast_url()
+	 * @see Archive_Page_Handler::maybe_redirect_archive_page_to_podcast_url()
 	 */
-	public function redirect_archive_page_to_podcast_url() {
-		$this->archive_page_handler->redirect_archive_page_to_podcast_url();
-	}
-
-	/**
-	 * @see Archive_Page_Handler::maybe_swap_archive_hierarchy()
-	 */
-	public function maybe_swap_archive_hierarchy( $templates ) {
-		return $this->archive_page_handler->maybe_swap_archive_hierarchy( $templates );
+	public function maybe_redirect_archive_page_to_podcast_url() {
+		$this->archive_page_handler->maybe_redirect_archive_page_to_podcast_url();
 	}
 
 	public function add_all_post_types_for_tag_archive( $query ) {

--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -145,6 +145,10 @@ class Frontend_Controller {
 		add_action( 'plugins_loaded', array( $this, 'load_localisation' ) );
 
 		add_filter( 'archive_template_hierarchy', array( $this, 'fix_template_hierarchy' ) );
+
+		// When a podcast archive page is assigned, redirect block/classic template
+		// resolution to the page hierarchy so the page's blocks render at /podcast/.
+		add_filter( 'archive_template_hierarchy', array( $this, 'maybe_swap_archive_hierarchy' ) );
 	}
 
 	/**
@@ -662,6 +666,13 @@ class Frontend_Controller {
 	 */
 	public function redirect_archive_page_to_podcast_url() {
 		$this->archive_page_handler->redirect_archive_page_to_podcast_url();
+	}
+
+	/**
+	 * @see Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 */
+	public function maybe_swap_archive_hierarchy( $templates ) {
+		return $this->archive_page_handler->maybe_swap_archive_hierarchy( $templates );
 	}
 
 	public function add_all_post_types_for_tag_archive( $query ) {

--- a/php/classes/handlers/class-archive-page-handler.php
+++ b/php/classes/handlers/class-archive-page-handler.php
@@ -186,6 +186,46 @@ class Archive_Page_Handler implements Service {
 	}
 
 	/**
+	 * Swaps the archive template hierarchy to the page hierarchy when the podcast
+	 * archive page is assigned.
+	 *
+	 * On block themes this causes `locate_block_template()` to resolve the theme's
+	 * `page` block template (instead of `archive-podcast` / `archive`), so
+	 * `$_wp_current_template_content` is populated with page-appropriate HTML.
+	 * Classic themes gain `page.php` as the primary candidate, matching the
+	 * fallback chain the `template_include` hook already uses.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param string[] $templates Template hierarchy in descending priority order.
+	 *
+	 * @return string[]
+	 */
+	public function maybe_swap_archive_hierarchy( $templates ) {
+		if ( ! is_post_type_archive( SSP_CPT_PODCAST ) ) {
+			return $templates;
+		}
+
+		if ( ! $this->is_podcast_page_assigned() ) {
+			return $templates;
+		}
+
+		$hierarchy = array();
+
+		$meta_slug = get_page_template_slug( $this->get_podcast_page_id() );
+
+		if ( $meta_slug ) {
+			$hierarchy[] = $meta_slug;
+		}
+
+		$hierarchy[] = 'page.php';
+		$hierarchy[] = 'singular.php';
+		$hierarchy[] = 'index.php';
+
+		return $hierarchy;
+	}
+
+	/**
 	 * Redirects the archive page's own URL to the podcast archive URL.
 	 *
 	 * The archive page uses a non-public slug (e.g. "ssp-podcast-archive") to avoid

--- a/php/classes/handlers/class-archive-page-handler.php
+++ b/php/classes/handlers/class-archive-page-handler.php
@@ -125,31 +125,35 @@ class Archive_Page_Handler implements Service {
 	}
 
 	/**
-	 * Replaces the main query with the assigned archive page.
+	 * Replaces the main query with the assigned archive page when the request
+	 * is the podcast CPT archive.
 	 *
-	 * Caller is responsible for checking that we're on the correct archive.
-	 * Returns the original template if no page is assigned or published.
+	 * Fires on `template_redirect`, before WP's tag-template dispatch — swapping
+	 * `is_post_type_archive` → `is_page` causes core to naturally resolve the
+	 * page template (via `get_page_template()`), which handles block themes,
+	 * classic themes, and `_wp_page_template` meta out of the box.
 	 *
 	 * @since 3.15.0
 	 *
-	 * @param string $template The path of the template to include.
-	 *
-	 * @return string
+	 * @return void
 	 */
-	public function serve_archive_page( $template ) {
+	public function maybe_serve_archive_page() {
+		if ( ! is_post_type_archive( SSP_CPT_PODCAST ) ) {
+			return;
+		}
+
 		$page_id = $this->get_podcast_page_id();
 
 		if ( ! $page_id ) {
-			return $template;
+			return;
 		}
 
 		$page = get_post( $page_id );
 
 		if ( ! $page || 'page' !== $page->post_type || 'publish' !== $page->post_status ) {
-			return $template;
+			return;
 		}
 
-		// Replace the main query with the page.
 		global $wp_query;
 
 		$wp_query->posts             = array( $page );
@@ -167,62 +171,7 @@ class Archive_Page_Handler implements Service {
 
 		$wp_query->rewind_posts();
 
-		// Enqueue podcast list styles — wp_enqueue_scripts has already fired,
-		// so this outputs in the footer.
 		wp_enqueue_style( 'ssp-podcast-list' );
-
-		// Resolve the page template.
-		$page_template_slug = get_page_template_slug( $page_id );
-
-		if ( $page_template_slug ) {
-			$resolved = locate_template( $page_template_slug );
-
-			if ( $resolved ) {
-				return $resolved;
-			}
-		}
-
-		return locate_template( array( 'page.php', 'singular.php', 'index.php' ) ) ?: $template;
-	}
-
-	/**
-	 * Swaps the archive template hierarchy to the page hierarchy when the podcast
-	 * archive page is assigned.
-	 *
-	 * On block themes this causes `locate_block_template()` to resolve the theme's
-	 * `page` block template (instead of `archive-podcast` / `archive`), so
-	 * `$_wp_current_template_content` is populated with page-appropriate HTML.
-	 * Classic themes gain `page.php` as the primary candidate, matching the
-	 * fallback chain the `template_include` hook already uses.
-	 *
-	 * @since 3.15.0
-	 *
-	 * @param string[] $templates Template hierarchy in descending priority order.
-	 *
-	 * @return string[]
-	 */
-	public function maybe_swap_archive_hierarchy( $templates ) {
-		if ( ! is_post_type_archive( SSP_CPT_PODCAST ) ) {
-			return $templates;
-		}
-
-		if ( ! $this->is_podcast_page_assigned() ) {
-			return $templates;
-		}
-
-		$hierarchy = array();
-
-		$meta_slug = get_page_template_slug( $this->get_podcast_page_id() );
-
-		if ( $meta_slug ) {
-			$hierarchy[] = $meta_slug;
-		}
-
-		$hierarchy[] = 'page.php';
-		$hierarchy[] = 'singular.php';
-		$hierarchy[] = 'index.php';
-
-		return $hierarchy;
 	}
 
 	/**
@@ -236,7 +185,7 @@ class Archive_Page_Handler implements Service {
 	 *
 	 * @return void
 	 */
-	public function redirect_archive_page_to_podcast_url() {
+	public function maybe_redirect_archive_page_to_podcast_url() {
 		$page_id = $this->get_podcast_page_id();
 
 		if ( ! $page_id || ! is_page( $page_id ) ) {

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.15.0-alpha.3
+ * Version: 3.15.0-alpha.4
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.15.0-alpha.3' );
+define( 'SSP_VERSION', '3.15.0-alpha.4' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/tests/WPUnit/ArchivePageTest.php
+++ b/tests/WPUnit/ArchivePageTest.php
@@ -420,6 +420,111 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	// =========================================================================
+	// Block-theme hierarchy swap: archive_template_hierarchy filter
+	// =========================================================================
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 */
+	public function testHierarchySwapReturnsOriginalWhenNoPageAssigned()
+	{
+		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
+
+		$this->go_to( home_url( '?post_type=podcast' ) );
+		$this->assertTrue( is_post_type_archive( SSP_CPT_PODCAST ) );
+
+		$original = array( 'archive-podcast.php', 'archive.php' );
+		$result   = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( $original );
+
+		$this->assertEquals( $original, $result );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 */
+	public function testHierarchySwapReturnsOriginalWhenNotOnPodcastArchive()
+	{
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		] );
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
+
+		$this->go_to( home_url( '/' ) );
+		$this->assertFalse( is_post_type_archive( SSP_CPT_PODCAST ) );
+
+		$original = array( 'archive.php' );
+		$result   = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( $original );
+
+		$this->assertEquals( $original, $result );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 */
+	public function testHierarchySwapReturnsPageHierarchyWhenTriggered()
+	{
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		] );
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
+
+		$this->go_to( home_url( '?post_type=podcast' ) );
+		$this->assertTrue( is_post_type_archive( SSP_CPT_PODCAST ) );
+
+		$original = array( 'archive-podcast.php', 'archive.php' );
+		$result   = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( $original );
+
+		$this->assertEquals( array( 'page.php', 'singular.php', 'index.php' ), $result );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 */
+	public function testHierarchySwapPrependsPageTemplateMetaSlug()
+	{
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		] );
+		update_post_meta( $page_id, '_wp_page_template', 'templates/full-width.php' );
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
+
+		$this->go_to( home_url( '?post_type=podcast' ) );
+
+		$result = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( array( 'archive-podcast.php' ) );
+
+		$this->assertEquals(
+			array( 'templates/full-width.php', 'page.php', 'singular.php', 'index.php' ),
+			$result
+		);
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 */
+	public function testHierarchySwapIgnoresDefaultTemplateMetaValue()
+	{
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		] );
+		update_post_meta( $page_id, '_wp_page_template', 'default' );
+		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
+
+		$this->go_to( home_url( '?post_type=podcast' ) );
+
+		$result = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( array( 'archive-podcast.php' ) );
+
+		$this->assertEquals(
+			array( 'page.php', 'singular.php', 'index.php' ),
+			$result,
+			'Meta value "default" resolves via get_page_template_slug() to an empty slug and must not be prepended.'
+		);
+	}
+
+	// =========================================================================
 	// Admin notice for existing installs
 	// =========================================================================
 

--- a/tests/WPUnit/ArchivePageTest.php
+++ b/tests/WPUnit/ArchivePageTest.php
@@ -371,78 +371,30 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	// =========================================================================
-	// Template override: serve page instead of CPT archive
+	// Query swap: template_redirect action
 	// =========================================================================
 
 	/**
-	 * @covers \SeriouslySimplePodcasting\Controllers\Frontend_Controller::maybe_serve_archive_page()
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_serve_archive_page()
 	 */
-	public function testServeArchivePageReturnsOriginalTemplateWhenNoPageAssigned()
-	{
-		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
-
-		$this->go_to( home_url( '/podcast/' ) );
-
-		// The filter is already registered by the plugin bootstrap.
-		$result = apply_filters( 'template_include', '/some/archive-podcast.php' );
-
-		$this->assertEquals( '/some/archive-podcast.php', $result );
-	}
-
-	/**
-	 * @covers \SeriouslySimplePodcasting\Controllers\Frontend_Controller::maybe_serve_archive_page()
-	 */
-	public function testServeArchivePageReplacesQueryWhenPageAssigned()
-	{
-		global $wpdb;
-
-		$page_id = $this->factory()->post->create( [
-			'post_type'   => 'page',
-			'post_status' => 'publish',
-			'post_title'  => 'Podcast',
-		] );
-
-		$wpdb->update( $wpdb->posts, [ 'post_name' => 'podcast-archive-test' ], [ 'ID' => $page_id ] );
-		clean_post_cache( $page_id );
-
-		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
-
-		// Use query string to simulate CPT archive (rewrite rules may not be loaded in tests).
-		$this->go_to( home_url( '?post_type=podcast' ) );
-		$this->assertTrue( is_post_type_archive( SSP_CPT_PODCAST ), 'Should be podcast archive' );
-
-		apply_filters( 'template_include', '/some/archive-podcast.php' );
-
-		global $wp_query;
-		$this->assertTrue( $wp_query->is_page );
-		$this->assertFalse( $wp_query->is_archive );
-		$this->assertEquals( $page_id, $wp_query->queried_object_id );
-	}
-
-	// =========================================================================
-	// Block-theme hierarchy swap: archive_template_hierarchy filter
-	// =========================================================================
-
-	/**
-	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
-	 */
-	public function testHierarchySwapReturnsOriginalWhenNoPageAssigned()
+	public function testServeArchivePageDoesNothingWhenNoPageAssigned()
 	{
 		delete_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID );
 
 		$this->go_to( home_url( '?post_type=podcast' ) );
 		$this->assertTrue( is_post_type_archive( SSP_CPT_PODCAST ) );
 
-		$original = array( 'archive-podcast.php', 'archive.php' );
-		$result   = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( $original );
+		$this->get_archive_page_handler()->maybe_serve_archive_page();
 
-		$this->assertEquals( $original, $result );
+		global $wp_query;
+		$this->assertTrue( $wp_query->is_post_type_archive, 'Query must not be swapped when no page is assigned.' );
+		$this->assertFalse( $wp_query->is_page );
 	}
 
 	/**
-	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_serve_archive_page()
 	 */
-	public function testHierarchySwapReturnsOriginalWhenNotOnPodcastArchive()
+	public function testServeArchivePageDoesNothingWhenNotOnPodcastArchive()
 	{
 		$page_id = $this->factory()->post->create( [
 			'post_type'   => 'page',
@@ -453,75 +405,34 @@ class ArchivePageTest extends \Codeception\TestCase\WPTestCase
 		$this->go_to( home_url( '/' ) );
 		$this->assertFalse( is_post_type_archive( SSP_CPT_PODCAST ) );
 
-		$original = array( 'archive.php' );
-		$result   = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( $original );
+		$this->get_archive_page_handler()->maybe_serve_archive_page();
 
-		$this->assertEquals( $original, $result );
+		global $wp_query;
+		$this->assertNotEquals( $page_id, $wp_query->queried_object_id );
 	}
 
 	/**
-	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
+	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_serve_archive_page()
 	 */
-	public function testHierarchySwapReturnsPageHierarchyWhenTriggered()
+	public function testServeArchivePageReplacesQueryWhenPageAssigned()
 	{
 		$page_id = $this->factory()->post->create( [
 			'post_type'   => 'page',
 			'post_status' => 'publish',
+			'post_title'  => 'Podcast',
 		] );
 		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
 
 		$this->go_to( home_url( '?post_type=podcast' ) );
-		$this->assertTrue( is_post_type_archive( SSP_CPT_PODCAST ) );
+		$this->assertTrue( is_post_type_archive( SSP_CPT_PODCAST ), 'Should be podcast archive' );
 
-		$original = array( 'archive-podcast.php', 'archive.php' );
-		$result   = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( $original );
+		$this->get_archive_page_handler()->maybe_serve_archive_page();
 
-		$this->assertEquals( array( 'page.php', 'singular.php', 'index.php' ), $result );
-	}
-
-	/**
-	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
-	 */
-	public function testHierarchySwapPrependsPageTemplateMetaSlug()
-	{
-		$page_id = $this->factory()->post->create( [
-			'post_type'   => 'page',
-			'post_status' => 'publish',
-		] );
-		update_post_meta( $page_id, '_wp_page_template', 'templates/full-width.php' );
-		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
-
-		$this->go_to( home_url( '?post_type=podcast' ) );
-
-		$result = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( array( 'archive-podcast.php' ) );
-
-		$this->assertEquals(
-			array( 'templates/full-width.php', 'page.php', 'singular.php', 'index.php' ),
-			$result
-		);
-	}
-
-	/**
-	 * @covers \SeriouslySimplePodcasting\Handlers\Archive_Page_Handler::maybe_swap_archive_hierarchy()
-	 */
-	public function testHierarchySwapIgnoresDefaultTemplateMetaValue()
-	{
-		$page_id = $this->factory()->post->create( [
-			'post_type'   => 'page',
-			'post_status' => 'publish',
-		] );
-		update_post_meta( $page_id, '_wp_page_template', 'default' );
-		update_option( Archive_Page_Handler::OPTION_PODCAST_PAGE_ID, $page_id );
-
-		$this->go_to( home_url( '?post_type=podcast' ) );
-
-		$result = $this->get_archive_page_handler()->maybe_swap_archive_hierarchy( array( 'archive-podcast.php' ) );
-
-		$this->assertEquals(
-			array( 'page.php', 'singular.php', 'index.php' ),
-			$result,
-			'Meta value "default" resolves via get_page_template_slug() to an empty slug and must not be prepended.'
-		);
+		global $wp_query;
+		$this->assertTrue( $wp_query->is_page );
+		$this->assertFalse( $wp_query->is_archive );
+		$this->assertFalse( $wp_query->is_post_type_archive );
+		$this->assertEquals( $page_id, $wp_query->queried_object_id );
 	}
 
 	// =========================================================================


### PR DESCRIPTION
## Summary
- Fix `/podcast/` rendering the theme's CPT archive template instead of the assigned page's blocks on block themes (#831). The query is now swapped on `template_redirect`, so WP's `get_page_template()` resolves the correct template for both block and classic themes — no hierarchy hacks, no `template_include` filter.
- Rename `serve_archive_page()` / `redirect_archive_page_to_podcast_url()` to `maybe_*` to match their internal conditional contracts.
- Drive-by: pulls in two pre-existing CR config tweaks already on the branch.

## Test plan
- [ ] On a block theme (Twenty Twenty-Five), visit `/podcast/` with an assigned archive page — confirm the page's blocks render (e.g. `seriously-simple-podcasting/podcast-list`), not `wp:query-title type:"archive"` + theme query loop
- [ ] On a classic theme, visit `/podcast/` with an assigned archive page — confirm behavior is unchanged
- [ ] Visit `/podcast/` with no archive page assigned — confirm the original CPT archive template still renders
- [ ] Visit the archive page's own slug (e.g. `/ssp-podcast-archive/`) — confirm 302 redirect to `/podcast/` still works
- [ ] Run `lando php vendor/bin/codecept run WPUnit ArchivePageTest` — all 23 cases pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked archive page handling and redirect logic for podcast archives to improve internal routing and template dispatch.

* **Tests**
  * Updated test coverage to match the revised archive handling behavior.

* **Chores**
  * Bumped plugin version to 3.15.0-alpha.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->