### PR TITLE
Memberships: fix single-sync cron race condition #838

### DIFF
--- a/php/classes/integrations/class-abstract-integrator.php
+++ b/php/classes/integrations/class-abstract-integrator.php
@@ -290,6 +290,10 @@ abstract class Abstract_Integrator {
 			return false;
 		}
 
+		// If a series is both revoked and added, add wins — don't revoke
+		// what we're about to re-add. Avoids redundant API calls.
+		$revoke_series_ids = array_diff( $revoke_series_ids, $add_series_ids );
+
 		if ( $revoke_series_ids ) {
 			$this->logger->log( __METHOD__ . sprintf( ': Revoke user %s from series %s', $user->user_email, json_encode( $revoke_series_ids ) ) );
 			$revoke_res = $this->revoke_subscriber_from_podcasts( $user, $revoke_series_ids );

--- a/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
+++ b/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
@@ -240,52 +240,114 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 	}
 
 	/**
-	 * Do single sync as the separate event to not interfere with the DB update process.
+	 * Queues a Castos add or revoke for a single membership based on its current status.
+	 *
+	 * @param \WC_Memberships_User_Membership $membership
 	 *
 	 * @return void
-	 * @see listen_user_membership_update()
+	 */
+	protected function sync_membership( $membership ) {
+		if ( 'active' === $membership->get_status() ) {
+			$this->prepare_single_sync( $membership->get_user_id(), $membership->get_plan_id(), null );
+		} else {
+			$this->prepare_single_sync( $membership->get_user_id(), null, $membership->get_plan_id() );
+		}
+	}
+
+	/**
+	 * Registers the single-sync cron callback.
+	 *
+	 * @return void
 	 */
 	protected function listen_single_sync() {
-		add_action(
-			self::SINGLE_SYNC_EVENT,
-			function () {
-				$single_update_data = get_option( self::SINGLE_SYNC_DATA_OPTION, array() );
-				if ( empty( $single_update_data['users'] ) ) {
-					return;
-				}
+		add_action( self::SINGLE_SYNC_EVENT, array( $this, 'process_single_sync' ) );
+	}
 
-				foreach ( $single_update_data['users'] as $user_id => $actions ) {
-					$revoked_memberships = $actions['revoked_memberships'];
-					$revoke_series_ids   = $this->convert_membership_ids_into_series_ids( $revoked_memberships );
+	/**
+	 * Processes queued single-sync users and performs race-safe cleanup.
+	 *
+	 * Takes a snapshot of the queue, syncs each user with Castos while
+	 * removing synced users from a $pending working copy. Hands both
+	 * snapshot and pending to cleanup, which detects concurrent writes
+	 * and preserves them (Scenario E).
+	 *
+	 * @return void
+	 */
+	public function process_single_sync() {
+		$snapshot = get_option( self::SINGLE_SYNC_DATA_OPTION, array() );
+		if ( empty( $snapshot['users'] ) ) {
+			return;
+		}
 
-					// Make sure user doesn't have other memberships that allow them to use this series
-					$user_membership_ids = $this->get_user_membership_ids( $user_id );
-					$allowed_series_ids  = $this->convert_membership_ids_into_series_ids( $user_membership_ids );
-					$revoke_series_ids   = array_diff( $revoke_series_ids, $allowed_series_ids );
+		if ( isset( $snapshot['attempts'] ) && (int) $snapshot['attempts'] >= 10 ) {
+			$this->logger->log( __METHOD__ . ': Giving up after 10 failed attempts.' );
+			return;
+		}
 
-					$added_memberships = $actions['added_memberships'];
-					$add_series_ids    = $this->convert_membership_ids_into_series_ids( $added_memberships );
+		$pending = $snapshot;
 
-					$res = $this->sync_user( $user_id, $revoke_series_ids, $add_series_ids );
+		foreach ( $snapshot['users'] as $user_id => $actions ) {
+			$revoke_series_ids = $this->convert_membership_ids_into_series_ids( $actions['revoked_memberships'] );
 
-					if ( ! $res ) {
-						// Let's make sure there won't be an infinite number of attempts.
-						if ( $single_update_data['attempts'] < 10 ) {
-							$this->logger->log( __METHOD__ . sprintf( ': Error! Could not sync user %s.', $user_id ) );
-						} else {
-							$this->logger->log( __METHOD__ . sprintf( ': Error! Failed to sync user %s. Will try again later.', $user_id ) );
-							$single_update_data['attempts'] = $single_update_data['attempts'] + 1;
-							update_option( self::SINGLE_SYNC_DATA_OPTION, $single_update_data );
-							$this->schedule_single_sync( 20 );
-						}
+			// Exclude series the user still has access to via other active memberships.
+			$user_membership_ids = $this->get_user_membership_ids( $user_id );
+			$allowed_series_ids  = $this->convert_membership_ids_into_series_ids( $user_membership_ids );
+			$revoke_series_ids   = array_diff( $revoke_series_ids, $allowed_series_ids );
 
-						return;
-					}
-				}
+			$add_series_ids = $this->convert_membership_ids_into_series_ids( $actions['added_memberships'] );
 
-				delete_option( self::SINGLE_SYNC_DATA_OPTION );
+			if ( $this->sync_user( $user_id, $revoke_series_ids, $add_series_ids ) ) {
+				unset( $pending['users'][ $user_id ] );
+			} else {
+				$this->logger->log( __METHOD__ . sprintf( ': Failed to sync user %s.', $user_id ) );
 			}
-		);
+		}
+
+		$updated = $this->reconcile_sync_data( $snapshot, $pending );
+
+		// Users remain (pending failures or concurrent writes) — save and reschedule.
+		if ( ! empty( $updated['users'] ) ) {
+			$updated['attempts'] = ( isset( $updated['attempts'] ) ? (int) $updated['attempts'] : 0 ) + 1;
+			update_option( self::SINGLE_SYNC_DATA_OPTION, $updated, false );
+			$had_sync_failures = count( $pending['users'] );
+			$this->schedule_single_sync( $had_sync_failures ? 20 : 0 );
+			return;
+		}
+
+		// Queue fully drained.
+		delete_option( self::SINGLE_SYNC_DATA_OPTION );
+	}
+
+	/**
+	 * Reconciles the sync option against the current DB state.
+	 *
+	 * Re-reads the option from DB (bypassing object cache), removes
+	 * successfully processed users whose data hasn't changed since the
+	 * snapshot, and preserves entries added or modified by concurrent
+	 * requests. Castos API is idempotent, so re-processing is safe.
+	 *
+	 * @param array $snapshot Option data as read before processing began.
+	 * @param array $pending  Working copy — only users that failed or weren't reached.
+	 *
+	 * @return array Reconciled option data ready to be persisted.
+	 */
+	protected function reconcile_sync_data( array $snapshot, array $pending ) {
+		// Bypass the object cache — concurrent requests write to DB directly;
+		// our in-process cache still holds the stale snapshot value.
+		wp_cache_delete( self::SINGLE_SYNC_DATA_OPTION, 'options' );
+		$stored = get_option( self::SINGLE_SYNC_DATA_OPTION, array() );
+
+		$updated = $stored;
+		foreach ( $snapshot['users'] as $uid => $actions ) {
+			if ( isset( $pending['users'][ $uid ] ) ) {
+				continue;
+			}
+			if ( isset( $updated['users'][ $uid ] ) && $updated['users'][ $uid ] === $actions ) {
+				unset( $updated['users'][ $uid ] );
+			}
+		}
+
+		return $updated;
 	}
 
 	/**
@@ -315,11 +377,7 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 
 				$user_membership = $this->get_user_membership( $user_membership_id );
 
-				if ( 'active' === $user_membership->get_status() ) {
-					$this->prepare_single_sync( $user_data['user_id'], $user_membership->get_plan_id(), null );
-				} else {
-					$this->prepare_single_sync( $user_data['user_id'], null, $user_membership->get_plan_id() );
-				}
+				$this->sync_membership( $user_membership );
 			},
 			10,
 			2
@@ -362,14 +420,25 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 			$single_sync_data['users'][ $user_id ]['revoked_memberships'] : array();
 
 		$single_sync_data['users'][ $user_id ] = array(
-			'added_memberships'   => array_unique( array_merge( $added_memberships, array( $added_membership ) ) ),
-			'revoked_memberships' => array_unique( array_merge( $revoked_memberships, array( $revoked_membership ) ) ),
+			'added_memberships'   => $this->clean_id_list( array_merge( $added_memberships, array( $added_membership ) ) ),
+			'revoked_memberships' => $this->clean_id_list( array_merge( $revoked_memberships, array( $revoked_membership ) ) ),
 		);
 
 		$single_sync_data['attempts'] = 0;
 
 		update_option( self::SINGLE_SYNC_DATA_OPTION, $single_sync_data, false );
 		$this->schedule_single_sync( 0 );
+	}
+
+	/**
+	 * Deduplicates an ID list, drops falsy values (null, 0, ''), and re-indexes sequentially.
+	 *
+	 * @param array $ids
+	 *
+	 * @return array
+	 */
+	protected function clean_id_list( array $ids ) {
+		return array_values( array_unique( array_filter( $ids ) ) );
 	}
 
 	/**

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.15.0-alpha.4
+ * Version: 3.15.1-beta.1
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.15.0-alpha.4' );
+define( 'SSP_VERSION', '3.15.1-beta.1' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/tests/WPUnit/WCMembershipsIntegratorTest.php
+++ b/tests/WPUnit/WCMembershipsIntegratorTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator;
+
+class WCMembershipsIntegratorTest extends \Codeception\TestCase\WPTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		delete_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+	}
+
+	protected function tearDown(): void {
+		delete_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		wp_clear_scheduled_hook( WC_Memberships_Integrator::SINGLE_SYNC_EVENT );
+		parent::tearDown();
+	}
+
+	/**
+	 * Builds a stub membership with the given status, user_id, and plan_id.
+	 */
+	protected function makeMembership( string $status, int $userId, int $planId ) {
+		return new class( $status, $userId, $planId ) {
+			private $status;
+			private $user_id;
+			private $plan_id;
+
+			public function __construct( $status, $userId, $planId ) {
+				$this->status  = $status;
+				$this->user_id = $userId;
+				$this->plan_id = $planId;
+			}
+
+			public function get_status() {
+				return $this->status;
+			}
+
+			public function get_user_id() {
+				return $this->user_id;
+			}
+
+			public function get_plan_id() {
+				return $this->plan_id;
+			}
+		};
+	}
+
+	/**
+	 * Invokes a protected method on the integrator via reflection.
+	 */
+	protected function invokeMethod( string $method, array $args = [] ) {
+		$integrator = WC_Memberships_Integrator::instance();
+		$ref        = new \ReflectionMethod( $integrator, $method );
+		$ref->setAccessible( true );
+		return $ref->invokeArgs( $integrator, $args );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::sync_membership()
+	 */
+	public function testSyncMembershipQueuesAddForActiveMembership() {
+		$this->invokeMethod( 'sync_membership', [ $this->makeMembership( 'active', 42, 100 ) ] );
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['added_memberships'] );
+		$this->assertNotContains( 100, $data['users'][42]['revoked_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::sync_membership()
+	 */
+	public function testSyncMembershipQueuesRevokeForNonActiveMembership() {
+		$this->invokeMethod( 'sync_membership', [ $this->makeMembership( 'paused', 42, 100 ) ] );
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['revoked_memberships'] );
+		$this->assertNotContains( 100, $data['users'][42]['added_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::prepare_single_sync()
+	 */
+	public function testPrepareSingleSyncFiltersNullValues() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['added_memberships'] );
+		$this->assertNotContains( null, $data['users'][42]['added_memberships'] );
+		$this->assertNotContains( null, $data['users'][42]['revoked_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::prepare_single_sync()
+	 */
+	public function testPrepareSingleSyncMergesDataForSameUser() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, null, 100 ] ); // revoke plan 100
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] ); // add plan 100
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['added_memberships'] );
+		$this->assertContains( 100, $data['users'][42]['revoked_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::prepare_single_sync()
+	 */
+	public function testPrepareSingleSyncDoesNotDuplicatePlanIds() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+
+		$data       = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$plan_count = count( array_keys( $data['users'][42]['added_memberships'], 100 ) );
+		$this->assertSame( 1, $plan_count );
+	}
+
+	/**
+	 * Helper: builds a $pending array from $snapshot with the given user IDs removed (processed).
+	 */
+	protected function buildPending( array $snapshot, array $processed_user_ids ): array {
+		$pending = $snapshot;
+		foreach ( $processed_user_ids as $uid ) {
+			unset( $pending['users'][ $uid ] );
+		}
+		return $pending;
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcileRemovesAllProcessedUsersWhenNoRace() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+		$this->invokeMethod( 'prepare_single_sync', [ 99, 200, null ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42, 99 ] ),
+		] );
+
+		$this->assertEmpty( $result['users'] );
+	}
+
+	/**
+	 * Scenario E: a concurrent write for a DIFFERENT user must survive reconciliation.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcilePreservesConcurrentWriteForDifferentUser() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, null, 100 ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		// Webhook writes user 99 while cron processes user 42.
+		$this->invokeMethod( 'prepare_single_sync', [ 99, 200, null ] );
+
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42 ] ),
+		] );
+
+		$this->assertArrayNotHasKey( 42, $result['users'] );
+		$this->assertArrayHasKey( 99, $result['users'] );
+		$this->assertContains( 200, $result['users'][99]['added_memberships'] );
+	}
+
+	/**
+	 * Scenario E: a concurrent write for the SAME user must survive reconciliation.
+	 * The snapshot won't match the current data, so the entry is kept.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcilePreservesConcurrentWriteForSameUser() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, null, 100 ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		// Webhook adds plan 100 for same user while cron processes the revoke.
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42 ] ),
+		] );
+
+		$this->assertArrayHasKey( 42, $result['users'] );
+		$this->assertContains( 100, $result['users'][42]['added_memberships'] );
+	}
+
+	/**
+	 * When a sync fails, successfully-processed users are removed
+	 * but pending users stay in the reconciled data.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcileOnPartialFailureKeepsPendingUsers() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+		$this->invokeMethod( 'prepare_single_sync', [ 99, 200, null ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		// User 42 succeeded, user 99 failed.
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42 ] ),
+		] );
+
+		$this->assertArrayNotHasKey( 42, $result['users'] );
+		$this->assertArrayHasKey( 99, $result['users'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Fix read-then-delete race condition in WC Memberships single-sync cron (Scenario E) — replace `delete_option()` with selective cleanup that re-reads the option from DB and only removes processed users whose data hasn't changed, preserving entries written by concurrent requests
- Fix inverted retry logic in `listen_single_sync` — was giving up on first failure, now correctly retries up to 10 times
- Extract `sync_membership()` shared by `_saved` handler (was inline), add `clean_id_list()` to prevent null plan IDs from polluting sync option
- Add `array_diff` guard in `sync_user()` (abstract integrator) to skip redundant revoke when same series is being added
- Add WPUnit tests for reconciliation logic covering concurrent-write scenarios

## Test plan
- [ ] Verify WPUnit tests pass (`codecept run WPUnit WCMembershipsIntegratorTest`)
- [ ] Verify existing membership sync still works: add/remove a WC Membership and confirm Castos subscriber status updates
- [ ] Verify bulk sync is unaffected
- [ ] If possible, test with Stripe test-mode gateway to trigger async renewal (Scenario E reproduction)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-membership single-sync queueing for targeted membership updates.

* **Bug Fixes**
  * Avoids unnecessary revocations when a membership is being re-added.
  * Improved queue reconciliation to fix race conditions and preserve concurrent updates.
  * Deduplicates and cleans plan ID lists to prevent duplicate entries.
  * Added retry/attempt limits and rescheduling for failed syncs.

* **Tests**
  * Added comprehensive unit tests covering single-sync queueing, reconciliation, and edge cases.

* **Chores**
  * Plugin version updated to 3.15.1-beta.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->