### PR TITLE
Default series toggle

### DIFF
--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -121,6 +121,57 @@ textarea#episode_embed_code {
   }
 }
 
+.ssp-default-podcast-label {
+  font-style: italic;
+  color: #64748B;
+  margin: 0;
+}
+
+.ssp-toggle {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  vertical-align: middle;
+}
+.ssp-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.ssp-toggle__slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: #ccc;
+  border-radius: 20px;
+  transition: background-color 0.2s;
+}
+.ssp-toggle__slider:before {
+  content: "";
+  position: absolute;
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+input:checked + .ssp-toggle__slider {
+  background-color: #2271b1;
+}
+input:checked + .ssp-toggle__slider:before {
+  transform: translateX(16px);
+}
+input:focus + .ssp-toggle__slider {
+  box-shadow: 0 0 0 2px #2271b1;
+}
+.ssp-toggle__label {
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 .ssp-error {
   background: #fff;
   border: 1px solid #c3c4c7;

--- a/assets/admin/scss/_admin.scss
+++ b/assets/admin/scss/_admin.scss
@@ -130,6 +130,64 @@ textarea#episode_embed_code {
 	}
 }
 
+.ssp-default-podcast-label {
+	font-style: italic;
+	color: $clr_gray_500;
+	margin: 0;
+}
+
+.ssp-toggle {
+	position: relative;
+	display: inline-block;
+	width: 36px;
+	height: 20px;
+	vertical-align: middle;
+
+	input {
+		opacity: 0;
+		width: 0;
+		height: 0;
+	}
+
+	&__slider {
+		position: absolute;
+		cursor: pointer;
+		inset: 0;
+		background-color: #ccc;
+		border-radius: 20px;
+		transition: background-color 0.2s;
+
+		&:before {
+			content: '';
+			position: absolute;
+			height: 14px;
+			width: 14px;
+			left: 3px;
+			bottom: 3px;
+			background-color: #fff;
+			border-radius: 50%;
+			transition: transform 0.2s;
+		}
+	}
+
+	input:checked + &__slider {
+		background-color: #2271b1;
+	}
+
+	input:checked + &__slider:before {
+		transform: translateX(16px);
+	}
+
+	input:focus + &__slider {
+		box-shadow: 0 0 0 2px #2271b1;
+	}
+
+	&__label {
+		margin-left: 8px;
+		vertical-align: middle;
+	}
+}
+
 .ssp-error {
 	background: #fff;
 	border: 1px solid #c3c4c7;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -335,6 +335,7 @@ jQuery(document).ready(function($) {
 
 	$('.ssp-image-delete').on('click', function(){
 		$('.' + $(this).data('field')).val('').trigger('change');
+		$('.' + $(this).data('field') + '_id').val('').trigger('change');
 		$('.' + $(this).data('preview')).attr('src', '').trigger('change');
 	});
 

--- a/php/classes/controllers/class-series-controller.php
+++ b/php/classes/controllers/class-series-controller.php
@@ -171,7 +171,26 @@ class Series_Controller {
 	public function edit_series_term_meta_fields( $term, $taxonomy ) {
 		// Add series image edit/upload metabox.
 		$this->series_image_uploader( $taxonomy, 'UPDATE', $term );
+		$this->show_default_podcast_toggle( $term );
 		$this->show_feed_info( $term );
+	}
+
+	/**
+	 * Renders the "Set as default podcast" toggle or a label if already default.
+	 *
+	 * @param \WP_Term $term
+	 */
+	protected function show_default_podcast_toggle( $term ) {
+		if ( ! current_user_can( 'manage_podcast' ) ) {
+			return;
+		}
+
+		$is_default = (int) $term->term_id === ssp_get_default_series_id();
+
+		ssp_renderer()->render(
+			'settings/podcast-default-toggle',
+			compact( 'is_default' )
+		);
 	}
 
 	/**
@@ -334,7 +353,29 @@ HTML;
 	 */
 	public function save_series_meta( $term_id, $tt_id ) {
 		$this->insert_update_series_meta( $term_id, $tt_id );
+		$this->maybe_set_default_series( $term_id );
 		$this->save_series_data_to_castos( $term_id );
+	}
+
+	/**
+	 * Sets this series as the default podcast if the toggle was checked.
+	 *
+	 * @param int $term_id
+	 */
+	protected function maybe_set_default_series( $term_id ) {
+		if ( empty( $_POST['ssp_default_podcast'] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_podcast' ) ) {
+			return;
+		}
+
+		if ( (int) $term_id === ssp_get_default_series_id() ) {
+			return;
+		}
+
+		ssp_update_option( 'default_series', (int) $term_id );
 	}
 
 	/**

--- a/php/classes/integrations/class-abstract-integrator.php
+++ b/php/classes/integrations/class-abstract-integrator.php
@@ -290,6 +290,10 @@ abstract class Abstract_Integrator {
 			return false;
 		}
 
+		// If a series is both revoked and added, add wins — don't revoke
+		// what we're about to re-add. Avoids redundant API calls.
+		$revoke_series_ids = array_diff( $revoke_series_ids, $add_series_ids );
+
 		if ( $revoke_series_ids ) {
 			$this->logger->log( __METHOD__ . sprintf( ': Revoke user %s from series %s', $user->user_email, json_encode( $revoke_series_ids ) ) );
 			$revoke_res = $this->revoke_subscriber_from_podcasts( $user, $revoke_series_ids );

--- a/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
+++ b/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
@@ -240,52 +240,114 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 	}
 
 	/**
-	 * Do single sync as the separate event to not interfere with the DB update process.
+	 * Queues a Castos add or revoke for a single membership based on its current status.
+	 *
+	 * @param \WC_Memberships_User_Membership $membership
 	 *
 	 * @return void
-	 * @see listen_user_membership_update()
+	 */
+	protected function sync_membership( $membership ) {
+		if ( 'active' === $membership->get_status() ) {
+			$this->prepare_single_sync( $membership->get_user_id(), $membership->get_plan_id(), null );
+		} else {
+			$this->prepare_single_sync( $membership->get_user_id(), null, $membership->get_plan_id() );
+		}
+	}
+
+	/**
+	 * Registers the single-sync cron callback.
+	 *
+	 * @return void
 	 */
 	protected function listen_single_sync() {
-		add_action(
-			self::SINGLE_SYNC_EVENT,
-			function () {
-				$single_update_data = get_option( self::SINGLE_SYNC_DATA_OPTION, array() );
-				if ( empty( $single_update_data['users'] ) ) {
-					return;
-				}
+		add_action( self::SINGLE_SYNC_EVENT, array( $this, 'process_single_sync' ) );
+	}
 
-				foreach ( $single_update_data['users'] as $user_id => $actions ) {
-					$revoked_memberships = $actions['revoked_memberships'];
-					$revoke_series_ids   = $this->convert_membership_ids_into_series_ids( $revoked_memberships );
+	/**
+	 * Processes queued single-sync users and performs race-safe cleanup.
+	 *
+	 * Takes a snapshot of the queue, syncs each user with Castos while
+	 * removing synced users from a $pending working copy. Hands both
+	 * snapshot and pending to cleanup, which detects concurrent writes
+	 * and preserves them (Scenario E).
+	 *
+	 * @return void
+	 */
+	public function process_single_sync() {
+		$snapshot = get_option( self::SINGLE_SYNC_DATA_OPTION, array() );
+		if ( empty( $snapshot['users'] ) ) {
+			return;
+		}
 
-					// Make sure user doesn't have other memberships that allow them to use this series
-					$user_membership_ids = $this->get_user_membership_ids( $user_id );
-					$allowed_series_ids  = $this->convert_membership_ids_into_series_ids( $user_membership_ids );
-					$revoke_series_ids   = array_diff( $revoke_series_ids, $allowed_series_ids );
+		if ( isset( $snapshot['attempts'] ) && (int) $snapshot['attempts'] >= 10 ) {
+			$this->logger->log( __METHOD__ . ': Giving up after 10 failed attempts.' );
+			return;
+		}
 
-					$added_memberships = $actions['added_memberships'];
-					$add_series_ids    = $this->convert_membership_ids_into_series_ids( $added_memberships );
+		$pending = $snapshot;
 
-					$res = $this->sync_user( $user_id, $revoke_series_ids, $add_series_ids );
+		foreach ( $snapshot['users'] as $user_id => $actions ) {
+			$revoke_series_ids = $this->convert_membership_ids_into_series_ids( $actions['revoked_memberships'] );
 
-					if ( ! $res ) {
-						// Let's make sure there won't be an infinite number of attempts.
-						if ( $single_update_data['attempts'] < 10 ) {
-							$this->logger->log( __METHOD__ . sprintf( ': Error! Could not sync user %s.', $user_id ) );
-						} else {
-							$this->logger->log( __METHOD__ . sprintf( ': Error! Failed to sync user %s. Will try again later.', $user_id ) );
-							$single_update_data['attempts'] = $single_update_data['attempts'] + 1;
-							update_option( self::SINGLE_SYNC_DATA_OPTION, $single_update_data );
-							$this->schedule_single_sync( 20 );
-						}
+			// Exclude series the user still has access to via other active memberships.
+			$user_membership_ids = $this->get_user_membership_ids( $user_id );
+			$allowed_series_ids  = $this->convert_membership_ids_into_series_ids( $user_membership_ids );
+			$revoke_series_ids   = array_diff( $revoke_series_ids, $allowed_series_ids );
 
-						return;
-					}
-				}
+			$add_series_ids = $this->convert_membership_ids_into_series_ids( $actions['added_memberships'] );
 
-				delete_option( self::SINGLE_SYNC_DATA_OPTION );
+			if ( $this->sync_user( $user_id, $revoke_series_ids, $add_series_ids ) ) {
+				unset( $pending['users'][ $user_id ] );
+			} else {
+				$this->logger->log( __METHOD__ . sprintf( ': Failed to sync user %s.', $user_id ) );
 			}
-		);
+		}
+
+		$updated = $this->reconcile_sync_data( $snapshot, $pending );
+
+		// Users remain (pending failures or concurrent writes) — save and reschedule.
+		if ( ! empty( $updated['users'] ) ) {
+			$updated['attempts'] = ( isset( $updated['attempts'] ) ? (int) $updated['attempts'] : 0 ) + 1;
+			update_option( self::SINGLE_SYNC_DATA_OPTION, $updated, false );
+			$had_sync_failures = count( $pending['users'] );
+			$this->schedule_single_sync( $had_sync_failures ? 20 : 0 );
+			return;
+		}
+
+		// Queue fully drained.
+		delete_option( self::SINGLE_SYNC_DATA_OPTION );
+	}
+
+	/**
+	 * Reconciles the sync option against the current DB state.
+	 *
+	 * Re-reads the option from DB (bypassing object cache), removes
+	 * successfully processed users whose data hasn't changed since the
+	 * snapshot, and preserves entries added or modified by concurrent
+	 * requests. Castos API is idempotent, so re-processing is safe.
+	 *
+	 * @param array $snapshot Option data as read before processing began.
+	 * @param array $pending  Working copy — only users that failed or weren't reached.
+	 *
+	 * @return array Reconciled option data ready to be persisted.
+	 */
+	protected function reconcile_sync_data( array $snapshot, array $pending ) {
+		// Bypass the object cache — concurrent requests write to DB directly;
+		// our in-process cache still holds the stale snapshot value.
+		wp_cache_delete( self::SINGLE_SYNC_DATA_OPTION, 'options' );
+		$stored = get_option( self::SINGLE_SYNC_DATA_OPTION, array() );
+
+		$updated = $stored;
+		foreach ( $snapshot['users'] as $uid => $actions ) {
+			if ( isset( $pending['users'][ $uid ] ) ) {
+				continue;
+			}
+			if ( isset( $updated['users'][ $uid ] ) && $updated['users'][ $uid ] === $actions ) {
+				unset( $updated['users'][ $uid ] );
+			}
+		}
+
+		return $updated;
 	}
 
 	/**
@@ -315,11 +377,7 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 
 				$user_membership = $this->get_user_membership( $user_membership_id );
 
-				if ( 'active' === $user_membership->get_status() ) {
-					$this->prepare_single_sync( $user_data['user_id'], $user_membership->get_plan_id(), null );
-				} else {
-					$this->prepare_single_sync( $user_data['user_id'], null, $user_membership->get_plan_id() );
-				}
+				$this->sync_membership( $user_membership );
 			},
 			10,
 			2
@@ -362,14 +420,25 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 			$single_sync_data['users'][ $user_id ]['revoked_memberships'] : array();
 
 		$single_sync_data['users'][ $user_id ] = array(
-			'added_memberships'   => array_unique( array_merge( $added_memberships, array( $added_membership ) ) ),
-			'revoked_memberships' => array_unique( array_merge( $revoked_memberships, array( $revoked_membership ) ) ),
+			'added_memberships'   => $this->clean_id_list( array_merge( $added_memberships, array( $added_membership ) ) ),
+			'revoked_memberships' => $this->clean_id_list( array_merge( $revoked_memberships, array( $revoked_membership ) ) ),
 		);
 
 		$single_sync_data['attempts'] = 0;
 
 		update_option( self::SINGLE_SYNC_DATA_OPTION, $single_sync_data, false );
 		$this->schedule_single_sync( 0 );
+	}
+
+	/**
+	 * Deduplicates an ID list, drops falsy values (null, 0, ''), and re-indexes sequentially.
+	 *
+	 * @param array $ids
+	 *
+	 * @return array
+	 */
+	protected function clean_id_list( array $ids ) {
+		return array_values( array_unique( array_filter( $ids ) ) );
 	}
 
 	/**

--- a/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
+++ b/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
@@ -247,11 +247,6 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 	 * @return void
 	 */
 	protected function sync_membership( $membership ) {
-		if ( ! $membership ) {
-			$this->logger->log( __METHOD__ . ': Membership lookup failed.' );
-			return;
-		}
-
 		if ( 'active' === $membership->get_status() ) {
 			$this->prepare_single_sync( $membership->get_user_id(), $membership->get_plan_id(), null );
 		} else {
@@ -286,7 +281,6 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 
 		if ( isset( $snapshot['attempts'] ) && (int) $snapshot['attempts'] >= 10 ) {
 			$this->logger->log( __METHOD__ . ': Giving up after 10 failed attempts.' );
-			delete_option( self::SINGLE_SYNC_DATA_OPTION );
 			return;
 		}
 

--- a/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
+++ b/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
@@ -247,6 +247,11 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 	 * @return void
 	 */
 	protected function sync_membership( $membership ) {
+		if ( ! $membership ) {
+			$this->logger->log( __METHOD__ . ': Membership lookup failed.' );
+			return;
+		}
+
 		if ( 'active' === $membership->get_status() ) {
 			$this->prepare_single_sync( $membership->get_user_id(), $membership->get_plan_id(), null );
 		} else {
@@ -281,6 +286,7 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 
 		if ( isset( $snapshot['attempts'] ) && (int) $snapshot['attempts'] >= 10 ) {
 			$this->logger->log( __METHOD__ . ': Giving up after 10 failed attempts.' );
+			delete_option( self::SINGLE_SYNC_DATA_OPTION );
 			return;
 		}
 

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.15.1-beta.1
+ * Version: 3.16.0-alpha
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.15.1-beta.1' );
+define( 'SSP_VERSION', '3.16.0-alpha' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.15.0
+ * Version: 3.15.1-beta.1
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.15.0' );
+define( 'SSP_VERSION', '3.15.1-beta.1' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/templates/settings/podcast-default-toggle.php
+++ b/templates/settings/podcast-default-toggle.php
@@ -13,13 +13,13 @@
 				<?php esc_html_e( 'This is the default podcast', 'seriously-simple-podcasting' ); ?>
 			</p>
 		<?php else : ?>
-			<label class="ssp-toggle">
-				<input type="checkbox" name="ssp_default_podcast" value="1" />
-				<span class="ssp-toggle__slider"></span>
+			<label class="ssp-toggle" for="ssp_default_podcast">
+				<input id="ssp_default_podcast" type="checkbox" name="ssp_default_podcast" value="1" />
+				<span class="ssp-toggle__slider" aria-hidden="true"></span>
+				<span class="ssp-toggle__label">
+					<?php esc_html_e( 'Set as default podcast', 'seriously-simple-podcasting' ); ?>
+				</span>
 			</label>
-			<span class="ssp-toggle__label">
-				<?php esc_html_e( 'Set as default podcast', 'seriously-simple-podcasting' ); ?>
-			</span>
 		<?php endif; ?>
 	</td>
 </tr>

--- a/templates/settings/podcast-default-toggle.php
+++ b/templates/settings/podcast-default-toggle.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @var bool $is_default
+ */
+?>
+<tr class="form-field term-default-podcast-wrap">
+	<th scope="row">
+		<label><?php esc_html_e( 'Default Podcast', 'seriously-simple-podcasting' ); ?></label>
+	</th>
+	<td>
+		<?php if ( $is_default ) : ?>
+			<p class="ssp-default-podcast-label">
+				<?php esc_html_e( 'This is the default podcast', 'seriously-simple-podcasting' ); ?>
+			</p>
+		<?php else : ?>
+			<label class="ssp-toggle">
+				<input type="checkbox" name="ssp_default_podcast" value="1" />
+				<span class="ssp-toggle__slider"></span>
+			</label>
+			<span class="ssp-toggle__label">
+				<?php esc_html_e( 'Set as default podcast', 'seriously-simple-podcasting' ); ?>
+			</span>
+		<?php endif; ?>
+	</td>
+</tr>

--- a/templates/settings/podcast-default-toggle.php
+++ b/templates/settings/podcast-default-toggle.php
@@ -13,13 +13,13 @@
 				<?php esc_html_e( 'This is the default podcast', 'seriously-simple-podcasting' ); ?>
 			</p>
 		<?php else : ?>
-			<label class="ssp-toggle" for="ssp_default_podcast">
-				<input id="ssp_default_podcast" type="checkbox" name="ssp_default_podcast" value="1" />
-				<span class="ssp-toggle__slider" aria-hidden="true"></span>
-				<span class="ssp-toggle__label">
-					<?php esc_html_e( 'Set as default podcast', 'seriously-simple-podcasting' ); ?>
-				</span>
+			<label class="ssp-toggle">
+				<input type="checkbox" name="ssp_default_podcast" value="1" />
+				<span class="ssp-toggle__slider"></span>
 			</label>
+			<span class="ssp-toggle__label">
+				<?php esc_html_e( 'Set as default podcast', 'seriously-simple-podcasting' ); ?>
+			</span>
 		<?php endif; ?>
 	</td>
 </tr>

--- a/tests/WPUnit/WCMembershipsIntegratorTest.php
+++ b/tests/WPUnit/WCMembershipsIntegratorTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator;
+
+class WCMembershipsIntegratorTest extends \Codeception\TestCase\WPTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		delete_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+	}
+
+	protected function tearDown(): void {
+		delete_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		wp_clear_scheduled_hook( WC_Memberships_Integrator::SINGLE_SYNC_EVENT );
+		parent::tearDown();
+	}
+
+	/**
+	 * Builds a stub membership with the given status, user_id, and plan_id.
+	 */
+	protected function makeMembership( string $status, int $userId, int $planId ) {
+		return new class( $status, $userId, $planId ) {
+			private $status;
+			private $user_id;
+			private $plan_id;
+
+			public function __construct( $status, $userId, $planId ) {
+				$this->status  = $status;
+				$this->user_id = $userId;
+				$this->plan_id = $planId;
+			}
+
+			public function get_status() {
+				return $this->status;
+			}
+
+			public function get_user_id() {
+				return $this->user_id;
+			}
+
+			public function get_plan_id() {
+				return $this->plan_id;
+			}
+		};
+	}
+
+	/**
+	 * Invokes a protected method on the integrator via reflection.
+	 */
+	protected function invokeMethod( string $method, array $args = [] ) {
+		$integrator = WC_Memberships_Integrator::instance();
+		$ref        = new \ReflectionMethod( $integrator, $method );
+		$ref->setAccessible( true );
+		return $ref->invokeArgs( $integrator, $args );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::sync_membership()
+	 */
+	public function testSyncMembershipQueuesAddForActiveMembership() {
+		$this->invokeMethod( 'sync_membership', [ $this->makeMembership( 'active', 42, 100 ) ] );
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['added_memberships'] );
+		$this->assertNotContains( 100, $data['users'][42]['revoked_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::sync_membership()
+	 */
+	public function testSyncMembershipQueuesRevokeForNonActiveMembership() {
+		$this->invokeMethod( 'sync_membership', [ $this->makeMembership( 'paused', 42, 100 ) ] );
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['revoked_memberships'] );
+		$this->assertNotContains( 100, $data['users'][42]['added_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::prepare_single_sync()
+	 */
+	public function testPrepareSingleSyncFiltersNullValues() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['added_memberships'] );
+		$this->assertNotContains( null, $data['users'][42]['added_memberships'] );
+		$this->assertNotContains( null, $data['users'][42]['revoked_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::prepare_single_sync()
+	 */
+	public function testPrepareSingleSyncMergesDataForSameUser() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, null, 100 ] ); // revoke plan 100
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] ); // add plan 100
+
+		$data = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$this->assertContains( 100, $data['users'][42]['added_memberships'] );
+		$this->assertContains( 100, $data['users'][42]['revoked_memberships'] );
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::prepare_single_sync()
+	 */
+	public function testPrepareSingleSyncDoesNotDuplicatePlanIds() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+
+		$data       = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+		$plan_count = count( array_keys( $data['users'][42]['added_memberships'], 100 ) );
+		$this->assertSame( 1, $plan_count );
+	}
+
+	/**
+	 * Helper: builds a $pending array from $snapshot with the given user IDs removed (processed).
+	 */
+	protected function buildPending( array $snapshot, array $processed_user_ids ): array {
+		$pending = $snapshot;
+		foreach ( $processed_user_ids as $uid ) {
+			unset( $pending['users'][ $uid ] );
+		}
+		return $pending;
+	}
+
+	/**
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcileRemovesAllProcessedUsersWhenNoRace() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+		$this->invokeMethod( 'prepare_single_sync', [ 99, 200, null ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42, 99 ] ),
+		] );
+
+		$this->assertEmpty( $result['users'] );
+	}
+
+	/**
+	 * Scenario E: a concurrent write for a DIFFERENT user must survive reconciliation.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcilePreservesConcurrentWriteForDifferentUser() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, null, 100 ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		// Webhook writes user 99 while cron processes user 42.
+		$this->invokeMethod( 'prepare_single_sync', [ 99, 200, null ] );
+
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42 ] ),
+		] );
+
+		$this->assertArrayNotHasKey( 42, $result['users'] );
+		$this->assertArrayHasKey( 99, $result['users'] );
+		$this->assertContains( 200, $result['users'][99]['added_memberships'] );
+	}
+
+	/**
+	 * Scenario E: a concurrent write for the SAME user must survive reconciliation.
+	 * The snapshot won't match the current data, so the entry is kept.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcilePreservesConcurrentWriteForSameUser() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, null, 100 ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		// Webhook adds plan 100 for same user while cron processes the revoke.
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42 ] ),
+		] );
+
+		$this->assertArrayHasKey( 42, $result['users'] );
+		$this->assertContains( 100, $result['users'][42]['added_memberships'] );
+	}
+
+	/**
+	 * When a sync fails, successfully-processed users are removed
+	 * but pending users stay in the reconciled data.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Integrations\Woocommerce\WC_Memberships_Integrator::reconcile_sync_data()
+	 */
+	public function testReconcileOnPartialFailureKeepsPendingUsers() {
+		$this->invokeMethod( 'prepare_single_sync', [ 42, 100, null ] );
+		$this->invokeMethod( 'prepare_single_sync', [ 99, 200, null ] );
+		$snapshot = get_option( WC_Memberships_Integrator::SINGLE_SYNC_DATA_OPTION );
+
+		// User 42 succeeded, user 99 failed.
+		$result = $this->invokeMethod( 'reconcile_sync_data', [
+			$snapshot,
+			$this->buildPending( $snapshot, [ 42 ] ),
+		] );
+
+		$this->assertArrayNotHasKey( 42, $result['users'] );
+		$this->assertArrayHasKey( 99, $result['users'] );
+	}
+}


### PR DESCRIPTION
## Summary

Allow admins to change the default podcast directly from the single series edit page, replacing the need for the SSA plugin's "Change Default Podcast" action.

## Requirements

- Non-default series edit page should display a toggle labeled "Set as default podcast"
- Toggling on and saving should update the `ss_podcasting_default_series` option to the current series
- The current default series should display a text label ("This is the default podcast") instead of a toggle
- Requires `manage_podcast` capability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Default Podcast" toggle in series settings.

* **Style**
  * New styles for the default-podcast label and a custom toggle control.

* **Bug Fixes**
  * Image delete now clears all associated fields.
  * Membership sync moved to queued single-sync processing and avoids conflicting add/revoke operations for more reliable syncing.

* **Tests**
  * Added tests covering membership sync queuing, merging, reconciliation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->