### PR TITLE
Improve Castos player accessibility (#811)

### DIFF
--- a/assets/js/castos-player.js
+++ b/assets/js/castos-player.js
@@ -13,6 +13,8 @@ docReady(function() {
 	/* Get Our Elements */
 	let players = document.querySelectorAll('.castos-player');
 
+	let i18n = window.ssp_player_i18n || {};
+
 	players.forEach(function (player) {
 		let playerId = player.dataset.player_id,
 			playerData = window['ssp_castos_player_' + playerId],
@@ -138,9 +140,11 @@ docReady(function() {
 			if (audio.volume === 1) {
 				audio.volume = 0;
 				volumeBtn.classList.add('off');
+				volumeBtn.setAttribute('aria-pressed', 'true');
 			} else {
 				audio.volume = 1;
 				volumeBtn.classList.remove('off');
+				volumeBtn.setAttribute('aria-pressed', 'false');
 			}
 		}
 
@@ -156,6 +160,7 @@ docReady(function() {
 
 			speedBtn.setAttribute('data-speed', speed);
 			speedBtn.innerHTML = speed + 'x';
+			speedBtn.setAttribute('aria-label', (i18n.playback_speed || 'Playback speed, currently %sx').replace('%s', speed));
 			audio.playbackRate = speed;
 		}
 
@@ -187,6 +192,7 @@ docReady(function() {
 				}
 
 				currentActiveItem.classList.remove('active');
+				currentActiveItem.removeAttribute('aria-selected');
 
 				let	nextItem = currentActiveItem.nextElementSibling;
 				if (nextItem) {
@@ -249,18 +255,41 @@ docReady(function() {
 			rssCopyBtn = player.querySelector('.copy-rss');
 
 		/* Build out functions */
-		function togglePanel(panel) {
+		function togglePanel(panel, triggerBtn) {
 			if(panel.classList.contains('open')){
 				panel.classList.remove('open');
+				if (triggerBtn) {
+					triggerBtn.setAttribute('aria-expanded', 'false');
+				}
 				return;
 			}
 			panel.classList.add('open');
+			if (triggerBtn) {
+				triggerBtn.setAttribute('aria-expanded', 'true');
+			}
 			panel.focus();
 		}
 
 		function copyLink(elm) {
 			elm.select();
 			document.execCommand('Copy');
+			announceToScreenReader(i18n.copied || 'Copied');
+		}
+
+		function announceToScreenReader(message) {
+			let announcer = player.querySelector('.ssp-sr-announce');
+			if (!announcer) {
+				announcer = document.createElement('div');
+				announcer.className = 'ssp-sr-announce';
+				announcer.setAttribute('aria-live', 'polite');
+				announcer.setAttribute('role', 'status');
+				announcer.style.cssText = 'position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;';
+				player.appendChild(announcer);
+			}
+			announcer.textContent = '';
+			setTimeout(function() {
+				announcer.textContent = message;
+			}, 100);
 		}
 
  		function handleChangePlaylistItem() {
@@ -269,10 +298,12 @@ docReady(function() {
 			}
 
 			playlistItems.querySelectorAll('.playlist__item').forEach(function (item) {
-				item.classList.remove('active')
+				item.classList.remove('active');
+				item.removeAttribute('aria-selected');
 			});
 
 			this.classList.add('active');
+			this.setAttribute('aria-selected', 'true');
 
 			let playlistEpisodeTitle = this.querySelector('.playlist__episode-title'),
 				episodeCover = this.querySelector('.playlist__item__cover img');
@@ -320,7 +351,7 @@ docReady(function() {
 
 					let div = document.createElement('div');
 					div.innerHTML =
-						'<li class="playlist__item" data-episode="' + escapeHtml(item.episode_id) + '">' +
+						'<li class="playlist__item" data-episode="' + escapeHtml(item.episode_id) + '" tabindex="0" role="option">' +
 						'<div class="playlist__item__cover">' +
 						'<img src="' + escapeUrl(item.album_art && item.album_art.src ? item.album_art.src : '') + '" title="' + escapeHtml(item.title) + '" alt="' + escapeHtml(item.title) + '" />' +
 						'</div>' +
@@ -387,25 +418,25 @@ docReady(function() {
 			/* Hook up the event listeners */
 			if (subscribeBtn) {
 				subscribeBtn.addEventListener('click', function () {
-					return togglePanel(subscribePanel);
+					return togglePanel(subscribePanel, subscribeBtn);
 				});
 			}
 
 			if (subscribePanelClose) {
 				subscribePanelClose.addEventListener('click', function () {
-					return togglePanel(subscribePanel);
+					return togglePanel(subscribePanel, subscribeBtn);
 				});
 			}
 
 			if (shareBtn) {
 				shareBtn.addEventListener('click', function () {
-					return togglePanel(sharePanel);
+					return togglePanel(sharePanel, shareBtn);
 				});
 			}
 
 			if (sharePanelClose) {
 				sharePanelClose.addEventListener('click', function () {
-					return togglePanel(sharePanel);
+					return togglePanel(sharePanel, shareBtn);
 				});
 			}
 
@@ -469,6 +500,16 @@ docReady(function() {
 					setSpeed( speed.toFixed( 1 ) );
 				} else if ( e.shiftKey && e.code === 'Digit0' ) { // Reset speed to 1x
 					setSpeed( 1 );
+				} else if ( 'Escape' === e.key ) {
+					e.preventDefault();
+					if ( subscribePanel && subscribePanel.classList.contains( 'open' ) ) {
+						togglePanel( subscribePanel, subscribeBtn );
+						subscribeBtn.focus();
+					}
+					if ( sharePanel && sharePanel.classList.contains( 'open' ) ) {
+						togglePanel( sharePanel, shareBtn );
+						shareBtn.focus();
+					}
 				}
 			} );
 		}

--- a/php/classes/controllers/class-players-controller.php
+++ b/php/classes/controllers/class-players-controller.php
@@ -408,6 +408,15 @@ class Players_Controller {
 			wp_enqueue_style( 'ssp-castos-player' );
 		}
 
+		static $i18n_localized = false;
+		if ( ! $i18n_localized && wp_script_is( 'ssp-castos-player', 'enqueued' ) ) {
+			wp_localize_script( 'ssp-castos-player', 'ssp_player_i18n', array(
+				'playback_speed' => __( 'Playback speed, currently %sx', 'seriously-simple-podcasting' ),
+				'copied'         => __( 'Copied', 'seriously-simple-podcasting' ),
+			) );
+			$i18n_localized = true;
+		}
+
 		$is_player_custom_colors_enabled = ssp_app()->get_settings_handler()->is_player_custom_colors_enabled();
 
 		if ( $is_player_custom_colors_enabled && ! wp_style_is( 'ssp-dynamic-style', 'enqueued' ) ) {

--- a/templates/players/castos-player.php
+++ b/templates/players/castos-player.php
@@ -25,7 +25,7 @@
 
 ?>
 <div id="<?php echo esc_attr( $player_id ); ?>" class="castos-player <?php echo esc_attr( $player_mode ) ?>-mode <?php echo esc_attr( $class )
-     ?>" tabindex="0" data-episode="<?php echo esc_attr( $episode_id ) ?>" data-player_id="<?php echo esc_attr( $player_id ); ?>">
+     ?>" role="region" aria-label="<?php esc_attr_e( 'Podcast player', 'seriously-simple-podcasting' ) ?>" data-episode="<?php echo esc_attr( $episode_id ) ?>" data-player_id="<?php echo esc_attr( $player_id ); ?>">
 	<div class="player">
 		<div class="player__main">
 			<div class="player__artwork player__artwork-<?php echo esc_attr( $episode_id ) ?>">
@@ -73,19 +73,16 @@
 						</div>
 						<div class="ssp-playback playback">
 							<div class="playback__controls">
-								<button class="player-btn player-btn__volume" title="<?php esc_attr_e( 'Mute/Unmute', 'seriously-simple-podcasting' ) ?>">
-									<span class="screen-reader-text"><?php esc_attr_e( 'Mute/Unmute Episode', 'seriously-simple-podcasting' ) ?></span>
+								<button class="player-btn player-btn__volume" title="<?php esc_attr_e( 'Mute/Unmute', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Mute audio', 'seriously-simple-podcasting' ) ?>" aria-pressed="false">
 								</button>
-								<button data-skip="-10" class="player-btn player-btn__rwd" title="<?php esc_attr_e( 'Rewind 10 seconds', 'seriously-simple-podcasting' ) ?>">
-									<span class="screen-reader-text"><?php esc_attr_e( 'Rewind 10 Seconds', 'seriously-simple-podcasting' ) ?></span>
+								<button data-skip="-10" class="player-btn player-btn__rwd" title="<?php esc_attr_e( 'Rewind 10 seconds', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Rewind 10 seconds', 'seriously-simple-podcasting' ) ?>">
 								</button>
-								<button data-speed="1" class="player-btn player-btn__speed" title="<?php esc_attr_e( 'Playback Speed', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Playback Speed', 'seriously-simple-podcasting' ) ?>">1x</button>
-								<button data-skip="30" class="player-btn player-btn__fwd" title="<?php esc_attr_e( 'Fast Forward 30 seconds', 'seriously-simple-podcasting' ) ?>">
-									<span class="screen-reader-text"><?php esc_attr_e( 'Fast Forward 30 seconds', 'seriously-simple-podcasting' ) ?></span>
+								<button data-speed="1" class="player-btn player-btn__speed" title="<?php esc_attr_e( 'Playback Speed', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Playback speed, currently 1x', 'seriously-simple-podcasting' ) ?>">1x</button>
+								<button data-skip="30" class="player-btn player-btn__fwd" title="<?php esc_attr_e( 'Fast Forward 30 seconds', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Fast forward 30 seconds', 'seriously-simple-podcasting' ) ?>">
 								</button>
 							</div>
 							<div class="playback__timers">
-								<time class="ssp-timer">00:00</time>
+								<time class="ssp-timer" aria-live="off">00:00</time>
 								<span>/</span>
 								<!-- We need actual duration here from the server -->
 								<time class="ssp-duration" datetime="<?php echo ssp_iso_duration( $duration ) ?>"><?php echo esc_html( $duration ) ?></time>
@@ -96,10 +93,10 @@
 				<?php if ( $show_subscribe_button || $show_share_button ) : ?>
 					<nav class="player-panels-nav">
 						<?php if ( $show_subscribe_button ) : ?>
-							<button class="subscribe-btn" id="subscribe-btn-<?php echo esc_attr( $episode_id ) ?>" title="<?php esc_attr_e( 'Subscribe', 'seriously-simple-podcasting' ) ?>"><?php esc_attr_e( 'Subscribe', 'seriously-simple-podcasting' ) ?></button>
+							<button class="subscribe-btn" id="subscribe-btn-<?php echo esc_attr( $episode_id ) ?>" title="<?php esc_attr_e( 'Subscribe', 'seriously-simple-podcasting' ) ?>" aria-expanded="false"><?php esc_attr_e( 'Subscribe', 'seriously-simple-podcasting' ) ?></button>
 						<?php endif; ?>
 						<?php if ( $show_share_button ) : ?>
-							<button class="share-btn" id="share-btn-<?php echo esc_attr( $episode_id ) ?>" title="<?php esc_attr_e( 'Share', 'seriously-simple-podcasting' ) ?>"><?php esc_attr_e( 'Share', 'seriously-simple-podcasting' ) ?></button>
+							<button class="share-btn" id="share-btn-<?php echo esc_attr( $episode_id ) ?>" title="<?php esc_attr_e( 'Share', 'seriously-simple-podcasting' ) ?>" aria-expanded="false"><?php esc_attr_e( 'Share', 'seriously-simple-podcasting' ) ?></button>
 						<?php endif; ?>
 					</nav>
 				<?php endif; ?>
@@ -110,10 +107,10 @@
 		<div class="player-panels player-panels-<?php echo esc_attr( $episode_id ) ?>">
 			<?php if ( $show_subscribe_button ) : ?>
 				<div class="subscribe player-panel subscribe-<?php echo esc_attr( $episode_id ) ?>">
-					<div class="close-btn close-btn-<?php echo esc_attr( $episode_id ) ?>">
+					<button class="close-btn close-btn-<?php echo esc_attr( $episode_id ) ?>" aria-label="<?php esc_attr_e( 'Close', 'seriously-simple-podcasting' ) ?>">
 						<span></span>
 						<span></span>
-					</div>
+					</button>
 					<div class="panel__inner">
 						<div class="subscribe-icons">
 							<?php foreach ( $subscribe_links as $key => $subscribe_link ) : ?>
@@ -139,25 +136,25 @@
 			<?php endif ?>
 			<?php if ( $show_share_button ) : ?>
 				<div class="share share-<?php echo esc_attr( $episode_id ) ?> player-panel">
-					<div class="close-btn close-btn-<?php echo esc_attr( $episode_id ) ?>">
+					<button class="close-btn close-btn-<?php echo esc_attr( $episode_id ) ?>" aria-label="<?php esc_attr_e( 'Close', 'seriously-simple-podcasting' ) ?>">
 						<span></span>
 						<span></span>
-					</div>
+					</button>
 					<div class="player-panel-row">
 						<div class="title">
 							<?php esc_attr_e( 'Share', 'seriously-simple-podcasting' ) ?>
 						</div>
 						<div class="icons-holder">
 							<a href="https://www.facebook.com/sharer/sharer.php?u=<?php echo esc_attr( $current_url ); ?>&t=<?php echo esc_attr( $episode->post_title ); ?>"
-							   target="_blank" rel="noopener noreferrer" class="share-icon facebook" title="<?php esc_attr_e( 'Share on Facebook', 'seriously-simple-podcasting' ) ?>">
+							   target="_blank" rel="noopener noreferrer" class="share-icon facebook" title="<?php esc_attr_e( 'Share on Facebook', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Share on Facebook', 'seriously-simple-podcasting' ) ?>">
 								<span></span>
 							</a>
 							<a href="https://twitter.com/intent/tweet?text=<?php echo esc_attr( $current_url ); ?>&url=<?php echo esc_attr( $episode->post_title ); ?>"
-							   target="_blank" rel="noopener noreferrer" class="share-icon twitter" title="<?php esc_attr_e( 'Share on Twitter', 'seriously-simple-podcasting' ) ?>">
+							   target="_blank" rel="noopener noreferrer" class="share-icon twitter" title="<?php esc_attr_e( 'Share on Twitter', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Share on Twitter', 'seriously-simple-podcasting' ) ?>">
 								<span></span>
 							</a>
 							<a href="<?php echo esc_url( $audio_file ) ?>"
-							   target="_blank" rel="noopener noreferrer" class="share-icon download" title="<?php esc_attr_e( 'Download', 'seriously-simple-podcasting' ) ?>" download>
+							   target="_blank" rel="noopener noreferrer" class="share-icon download" title="<?php esc_attr_e( 'Download', 'seriously-simple-podcasting' ) ?>" aria-label="<?php esc_attr_e( 'Download', 'seriously-simple-podcasting' ) ?>" download>
 								<span></span>
 							</a>
 						</div>
@@ -190,10 +187,11 @@
 	<?php if ( ! empty( $playlist ) ) : ?>
 		<div class="playlist__wrapper" data-page="1">
 			<div class="loader"></div>
-			<ul class="playlist__items">
+			<ul class="playlist__items" role="listbox">
 				<?php foreach ( $playlist as $k => $item ) : ?>
 					<li class="playlist__item<?php if ( 0 === $k ): ?> active<?php endif ?>"
-						data-episode="<?php echo esc_attr( $item['episode_id'] ); ?>">
+						data-episode="<?php echo esc_attr( $item['episode_id'] ); ?>"
+						tabindex="0" role="option"<?php if ( 0 === $k ): ?> aria-selected="true"<?php endif ?>>
 						<div class="playlist__item__cover">
 							<img src="<?php echo esc_attr( $item['album_art']['src'] ) ?>" title="<?php echo esc_attr( strip_tags( $item['title'] ) ); ?>" alt="<?php echo esc_attr( strip_tags( $item['title'] ) ) ?>"/>
 						</div>

--- a/tests/WPUnit/PlayersControllerTest.php
+++ b/tests/WPUnit/PlayersControllerTest.php
@@ -58,6 +58,7 @@ class PlayersControllerTest extends \Codeception\TestCase\WPTestCase
 
         $player_parts = [
             'class="castos-player dark-mode',
+            'role="region" aria-label="Podcast player"',
             '<div class="currently-playing">',
             sprintf('<div class="episode-title player__episode-title">%s</div>', $episode->post_title),
             '<div class="play-progress">',
@@ -73,24 +74,21 @@ class PlayersControllerTest extends \Codeception\TestCase\WPTestCase
 
             '<div class="ssp-playback playback">',
             '<div class="playback__controls">',
-            '<button class="player-btn player-btn__volume" title="Mute/Unmute">',
-            '<span class="screen-reader-text">Mute/Unmute Episode</span>',
+            '<button class="player-btn player-btn__volume" title="Mute/Unmute" aria-label="Mute audio" aria-pressed="false">',
 
-            '<button data-skip="-10" class="player-btn player-btn__rwd" title="Rewind 10 seconds">',
-            '<span class="screen-reader-text">Rewind 10 Seconds</span>',
-            '<button data-speed="1" class="player-btn player-btn__speed" title="Playback Speed" aria-label="Playback Speed">1x</button>',
-            '<button data-skip="30" class="player-btn player-btn__fwd" title="Fast Forward 30 seconds">',
-            '<span class="screen-reader-text">Fast Forward 30 seconds</span>',
+            '<button data-skip="-10" class="player-btn player-btn__rwd" title="Rewind 10 seconds" aria-label="Rewind 10 seconds">',
+            '<button data-speed="1" class="player-btn player-btn__speed" title="Playback Speed" aria-label="Playback speed, currently 1x">1x</button>',
+            '<button data-skip="30" class="player-btn player-btn__fwd" title="Fast Forward 30 seconds" aria-label="Fast forward 30 seconds">',
             '<div class="playback__timers">',
-            '<time class="ssp-timer">00:00</time>',
+            '<time class="ssp-timer" aria-live="off">00:00</time>',
             '<time class="ssp-duration" datetime="PT0H0M0S"></time>',
 
             '<nav class="player-panels-nav">',
-            sprintf('<button class="subscribe-btn" id="subscribe-btn-%s" title="Subscribe">Subscribe</button>', $episode_id),
-            sprintf('<button class="share-btn" id="share-btn-%s" title="Share">Share</button>', $episode_id),
+            sprintf('<button class="subscribe-btn" id="subscribe-btn-%s" title="Subscribe" aria-expanded="false">Subscribe</button>', $episode_id),
+            sprintf('<button class="share-btn" id="share-btn-%s" title="Share" aria-expanded="false">Share</button>', $episode_id),
             sprintf('<div class="player-panels player-panels-%s">', $episode_id),
             sprintf('<div class="subscribe player-panel subscribe-%s">', $episode_id),
-            sprintf('<div class="close-btn close-btn-%s">', $episode_id),
+            sprintf('<button class="close-btn close-btn-%s" aria-label="Close">', $episode_id),
 
             '<div class="panel__inner">',
             '<div class="subscribe-icons">',
@@ -103,7 +101,7 @@ class PlayersControllerTest extends \Codeception\TestCase\WPTestCase
             sprintf('<button class="copy-rss copy-rss-%s" title="Copy RSS Feed URL" aria-label="Copy RSS Feed URL"></button>', $episode_id),
 
             sprintf('<div class="share share-%s player-panel">', $episode_id),
-            sprintf('<div class="close-btn close-btn-%s">', $episode_id),
+            sprintf('<button class="close-btn close-btn-%s" aria-label="Close">', $episode_id),
 
             '<div class="player-panel-row">',
 
@@ -114,14 +112,14 @@ class PlayersControllerTest extends \Codeception\TestCase\WPTestCase
                 $permalink,
                 $episode->post_title
             ),
-            'target="_blank" rel="noopener noreferrer" class="share-icon facebook" title="Share on Facebook"',
+            'target="_blank" rel="noopener noreferrer" class="share-icon facebook" title="Share on Facebook" aria-label="Share on Facebook"',
             sprintf(
                 '<a href="https://twitter.com/intent/tweet?text=%s&url=%s"',
                 $permalink,
                 $episode->post_title
             ),
-            'target="_blank" rel="noopener noreferrer" class="share-icon twitter" title="Share on Twitter">',
-            'target="_blank" rel="noopener noreferrer" class="share-icon download" title="Download" download>',
+            'target="_blank" rel="noopener noreferrer" class="share-icon twitter" title="Share on Twitter" aria-label="Share on Twitter">',
+            'target="_blank" rel="noopener noreferrer" class="share-icon download" title="Download" aria-label="Download" download>',
             '<div class="title">',
             'Link',
             sprintf('<input value="%s" class="input-link input-link-%d" title="Episode URL" readonly />', $permalink, $episode_id),


### PR DESCRIPTION
## Summary
- Add WCAG ARIA attributes to the Castos podcast player for screen reader support
- Mute button: `aria-pressed` toggle; speed button: dynamic `aria-label` with current speed
- Subscribe/Share panels: `aria-expanded` on trigger buttons, Escape key to close
- Playlist items: `role="listbox"`/`role="option"` with `aria-selected` on active item
- Copy actions: `aria-live="polite"` region announces "Copied" to screen readers
- Close buttons changed from `<div>` to semantic `<button>` with `aria-label`
- Dynamic JS labels use `wp_localize_script` for i18n support

## Test plan
- [ ] Verify player controls are keyboard-navigable (Tab, Space, Arrow keys, M for mute, Shift+./Shift+, for speed)
- [ ] Test mute button announces pressed/not-pressed state in screen reader
- [ ] Test speed button announces current speed on change
- [ ] Test Subscribe/Share panels: `aria-expanded` toggles, Escape closes and returns focus
- [ ] Test playlist items: Tab to navigate, active item announced as selected
- [ ] Test copy buttons (RSS, Link, Embed): screen reader announces "Copied"
- [ ] Verify no visual regression in player appearance
- [ ] Run WPUnit tests (`codecept run WPUnit PlayersControllerTest`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Escape key) to close subscribe/share panels and return focus to the triggering button

* **Enhancements**
  * Improved control button labels and interface descriptions for better clarity
  * Enhanced playlist item navigation and interaction controls
  * Added internationalization support to player interface elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->