### PR TITLE
Fix WC Memberships: null guard and retry queue cleanup #838

### DIFF
--- a/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
+++ b/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
@@ -286,7 +286,19 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 
 		if ( isset( $snapshot['attempts'] ) && (int) $snapshot['attempts'] >= 10 ) {
 			$this->logger->log( __METHOD__ . ': Giving up after 10 failed attempts.' );
-			delete_option( self::SINGLE_SYNC_DATA_OPTION );
+
+			// Drop capped snapshot users but preserve any concurrent writes.
+			$empty_pending = array( 'users' => array() );
+			$updated       = $this->reconcile_sync_data( $snapshot, $empty_pending );
+
+			if ( empty( $updated['users'] ) ) {
+				delete_option( self::SINGLE_SYNC_DATA_OPTION );
+			} else {
+				$updated['attempts'] = 0;
+				update_option( self::SINGLE_SYNC_DATA_OPTION, $updated, false );
+				$this->schedule_single_sync( 0 );
+			}
+
 			return;
 		}
 

--- a/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
+++ b/php/classes/integrations/woocommerce/class-wc-memberships-integrator.php
@@ -247,6 +247,11 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 	 * @return void
 	 */
 	protected function sync_membership( $membership ) {
+		if ( ! $membership ) {
+			$this->logger->log( __METHOD__ . ': Membership lookup failed.' );
+			return;
+		}
+
 		if ( 'active' === $membership->get_status() ) {
 			$this->prepare_single_sync( $membership->get_user_id(), $membership->get_plan_id(), null );
 		} else {
@@ -281,6 +286,7 @@ class WC_Memberships_Integrator extends Abstract_Integrator {
 
 		if ( isset( $snapshot['attempts'] ) && (int) $snapshot['attempts'] >= 10 ) {
 			$this->logger->log( __METHOD__ . ': Giving up after 10 failed attempts.' );
+			delete_option( self::SINGLE_SYNC_DATA_OPTION );
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- Guard `sync_membership()` against null membership lookups to prevent fatal errors when `get_user_membership()` returns null
- Clear the `SINGLE_SYNC_DATA_OPTION` queue when the 10-attempt retry cap is reached, so stranded users don't block future syncs

## Test plan
- [ ] Verify WC Memberships single sync still works for active/revoked memberships
- [ ] Verify that after 10 failed sync attempts the queue option is cleaned up
- [ ] Run WPUnit `WCMembershipsIntegratorTest` suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when a membership lookup fails by stopping the sync and logging the failure.
  * Reconciled capped/queued membership sync snapshots with current state to avoid losing pending changes.
  * Reset retry counters and reschedule single-item syncs when needed to preserve concurrent updates and avoid indefinite retry loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->