### PR TITLE
Use featured image as player artwork fallback #843

### DIFF
--- a/php/classes/repositories/class-episode-repository.php
+++ b/php/classes/repositories/class-episode-repository.php
@@ -857,7 +857,19 @@ class Episode_Repository implements Service {
 		}
 
 		/**
-		 * Option 5: None of the above passed, return the no-album-art image
+		 * Option 5: if the post has a featured image, use that (no squareness check —
+		 * the HTML5 player handles non-square images via CSS)
+		 */
+		$thumb_id = get_post_thumbnail_id( $episode_id );
+		if ( ! empty( $thumb_id ) ) {
+			$image_data_array = ssp_get_attachment_image_src( $thumb_id, $size );
+			if ( ! empty( $image_data_array['src'] ) ) {
+				return apply_filters( 'ssp_album_art', $image_data_array, $episode_id, $size, 'featured_image' );
+			}
+		}
+
+		/**
+		 * Option 6: None of the above passed, return the no-album-art image
 		 */
 		$image_data_array = $this->get_no_album_art_image_array();
 

--- a/tests/WPUnit/EpisodeRepositoryAlbumArtTest.php
+++ b/tests/WPUnit/EpisodeRepositoryAlbumArtTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Repositories\Episode_Repository;
+
+class EpisodeRepositoryAlbumArtTest extends \Codeception\TestCase\WPTestCase
+{
+    /**
+     * @var Episode_Repository
+     */
+    protected $episode_repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->episode_repository = ssp_get_service('episode_repository');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Creates a test episode post.
+     *
+     * @return int Post ID.
+     */
+    protected function createEpisode()
+    {
+        return $this->factory()->post->create([
+            'post_status' => 'publish',
+            'post_type'   => SSP_CPT_PODCAST,
+        ]);
+    }
+
+    /**
+     * Creates an attachment post with image metadata.
+     *
+     * @param int $width  Image width.
+     * @param int $height Image height.
+     *
+     * @return int Attachment ID.
+     */
+    protected function createAttachment($width = 800, $height = 600)
+    {
+        $filename = 'test-image-' . wp_rand() . '.png';
+
+        $attachment_id = $this->factory()->attachment->create([
+            'post_mime_type' => 'image/png',
+            'post_type'     => 'attachment',
+        ]);
+
+        // _wp_attached_file is required for wp_get_attachment_image_src() to return a URL.
+        update_post_meta($attachment_id, '_wp_attached_file', $filename);
+        wp_update_attachment_metadata($attachment_id, [
+            'width'  => $width,
+            'height' => $height,
+            'file'   => $filename,
+            'sizes'  => [],
+        ]);
+
+        return $attachment_id;
+    }
+
+    /**
+     * @covers Episode_Repository::get_album_art()
+     */
+    public function testReturnsFeaturedImageWhenNoOtherImagesExist()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(1200, 800);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        $result = $this->episode_repository->get_album_art($episode_id);
+
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result['src']);
+        $this->assertStringNotContainsString('no-album-art', $result['src']);
+    }
+
+    /**
+     * @covers Episode_Repository::get_album_art()
+     */
+    public function testSkipsFeaturedImageWhenCoverImageExists()
+    {
+        $episode_id          = $this->createEpisode();
+        $cover_attachment_id = $this->createAttachment(1400, 1400);
+        $feat_attachment_id  = $this->createAttachment(1200, 800);
+
+        update_post_meta($episode_id, 'cover_image_id', $cover_attachment_id);
+        set_post_thumbnail($episode_id, $feat_attachment_id);
+
+        $result = $this->episode_repository->get_album_art($episode_id);
+
+        // Should return the square cover image, not the featured image.
+        $this->assertIsArray($result);
+        $cover_src = wp_get_attachment_image_src($cover_attachment_id, 'full');
+        $this->assertNotFalse($cover_src, 'Cover attachment must resolve to an image URL.');
+        $this->assertSame($cover_src[0], $result['src']);
+    }
+
+    /**
+     * @covers Episode_Repository::get_album_art()
+     */
+    public function testFeaturedImageDoesNotRequireSquareness()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(1600, 900);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        $result = $this->episode_repository->get_album_art($episode_id);
+
+        // Should return the non-square featured image instead of placeholder.
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result['src']);
+        $this->assertStringNotContainsString('no-album-art', $result['src']);
+    }
+
+    /**
+     * @covers Episode_Repository::get_album_art()
+     */
+    public function testReturnsPlaceholderWhenNoFeaturedImageExists()
+    {
+        $episode_id = $this->createEpisode();
+
+        $result = $this->episode_repository->get_album_art($episode_id);
+
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('no-album-art', $result['src']);
+    }
+}

--- a/tests/WPUnit/EpisodeRepositoryAlbumArtTest.php
+++ b/tests/WPUnit/EpisodeRepositoryAlbumArtTest.php
@@ -15,6 +15,7 @@ class EpisodeRepositoryAlbumArtTest extends \Codeception\TestCase\WPTestCase
     {
         parent::setUp();
         $this->episode_repository = ssp_get_service('episode_repository');
+        delete_option('ss_podcasting_data_image');
     }
 
     protected function tearDown(): void
@@ -77,8 +78,9 @@ class EpisodeRepositoryAlbumArtTest extends \Codeception\TestCase\WPTestCase
         $result = $this->episode_repository->get_album_art($episode_id);
 
         $this->assertIsArray($result);
-        $this->assertNotEmpty($result['src']);
-        $this->assertStringNotContainsString('no-album-art', $result['src']);
+        $featured_src = wp_get_attachment_image_src($attachment_id, 'full');
+        $this->assertNotFalse($featured_src, 'Featured attachment must resolve to an image URL.');
+        $this->assertSame($featured_src[0], $result['src']);
     }
 
     /**
@@ -116,8 +118,9 @@ class EpisodeRepositoryAlbumArtTest extends \Codeception\TestCase\WPTestCase
 
         // Should return the non-square featured image instead of placeholder.
         $this->assertIsArray($result);
-        $this->assertNotEmpty($result['src']);
-        $this->assertStringNotContainsString('no-album-art', $result['src']);
+        $featured_src = wp_get_attachment_image_src($attachment_id, 'full');
+        $this->assertNotFalse($featured_src, 'Featured attachment must resolve to an image URL.');
+        $this->assertSame($featured_src[0], $result['src']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add post featured image as a fallback in `get_album_art()` after cover/series/feed images and before the placeholder
- Skip squareness check for the featured image — the HTML5 player handles non-square via CSS
- Resolves CastosHQ/ssp-issues#843

## Test plan
- [ ] Verify episode with featured image (no cover/series/feed image) shows featured image in player instead of placeholder
- [ ] Verify episode with cover image still shows cover image (not featured image)
- [ ] Verify episode with no images at all still shows placeholder
- [ ] Run `vendor/bin/codecept run WPUnit EpisodeRepositoryAlbumArtTest` — 4 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Album art selection now falls back to the episode’s featured image when primary sources don’t provide artwork, and no longer requires featured images to be square.

* **Tests**
  * Added unit tests covering album art selection: featured-image fallback, preference when alternate cover exists, non-square featured images, and placeholder fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->