### PR TITLE
Clear disconnect notice when Castos is reconnected

### DIFF
--- a/php/classes/handlers/class-admin-notifications-handler.php
+++ b/php/classes/handlers/class-admin-notifications-handler.php
@@ -310,9 +310,10 @@ class Admin_Notifications_Handler implements Service {
 	 *
 	 * @return void
 	 */
-	public function add_constant_notice( $notice, $type ) {
-		$notices                                      = $this->get_constant_notices();
-		$notices[ $this->get_notice_hash( $notice ) ] = array(
+	public function add_constant_notice( $notice, $type, $key = '' ) {
+		$notices         = $this->get_constant_notices();
+		$key             = $key ?: $this->get_notice_hash( $notice );
+		$notices[ $key ] = array(
 			'notice'      => $notice,
 			'type'        => $type,
 			'dismissible' => 'is-dismissible is-constant',

--- a/php/classes/handlers/class-admin-notifications-handler.php
+++ b/php/classes/handlers/class-admin-notifications-handler.php
@@ -312,6 +312,7 @@ class Admin_Notifications_Handler implements Service {
 	 */
 	public function add_constant_notice( $notice, $type, $key = '' ) {
 		$notices         = $this->get_constant_notices();
+		$key             = $key ? sanitize_key( $key ) : '';
 		$key             = $key ?: $this->get_notice_hash( $notice );
 		$notices[ $key ] = array(
 			'notice'      => $notice,

--- a/php/classes/handlers/class-ajax-handler.php
+++ b/php/classes/handlers/class-ajax-handler.php
@@ -253,6 +253,7 @@ class Ajax_Handler {
 			}
 
 			$this->castos_handler->set_token( $account_api_token );
+			$this->admin_notices_handler->remove_constant_notice( Castos_Handler::DISCONNECT_NOTICE_KEY );
 
 			$this->admin_notices_handler->add_flash_notice( $response->message, Admin_Notifications_Handler::SUCCESS );
 

--- a/php/classes/handlers/class-castos-handler.php
+++ b/php/classes/handlers/class-castos-handler.php
@@ -65,6 +65,13 @@ class Castos_Handler implements Service {
 	const API_TOKEN_OPTION = 'ss_podcasting_podmotor_account_api_token';
 
 	/**
+	 * Key used to store and remove the disconnect constant notice.
+	 *
+	 * @const string
+	 */
+	const DISCONNECT_NOTICE_KEY = 'castos_disconnected';
+
+	/**
 	 * Transient name for storing cached podcasts data.
 	 *
 	 * @const string
@@ -1116,7 +1123,7 @@ class Castos_Handler implements Service {
 		$this->remove_api_credentials();
 
 		if ( $notification ) {
-			$this->notifications_handler->add_constant_notice( $notification, Admin_Notifications_Handler::WARNING );
+			$this->notifications_handler->add_constant_notice( $notification, Admin_Notifications_Handler::WARNING, self::DISCONNECT_NOTICE_KEY );
 		}
 	}
 

--- a/tests/WPUnit/AjaxHandlerTest.php
+++ b/tests/WPUnit/AjaxHandlerTest.php
@@ -15,7 +15,7 @@ class AjaxHandlerTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	protected function tearDown(): void {
-		unset( $_POST['post_id'], $_POST['width'], $_POST['height'], $_REQUEST['nonce'] );
+		unset( $_POST['post_id'], $_POST['width'], $_POST['height'], $_REQUEST['nonce'], $_GET['api_token'] );
 		parent::tearDown();
 	}
 
@@ -118,6 +118,37 @@ class AjaxHandlerTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertNotNull( $decoded, 'Response should be valid JSON. Got: ' . $output );
 
 		return $decoded;
+	}
+
+	/**
+	 * Test that connect_castos removes the disconnect notice on successful reconnection.
+	 */
+	public function testConnectCastosRemovesDisconnectNoticeOnSuccess() {
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$user = wp_get_current_user();
+		$user->add_cap( 'manage_podcast' );
+
+		$_REQUEST['nonce'] = wp_create_nonce( 'ss_podcasting_castos-hosting' );
+		$_GET['api_token'] = 'test_token_123';
+
+		$response          = new \SeriouslySimplePodcasting\Entities\Castos_Response();
+		$response->success = true;
+		$response->message = 'Connected successfully.';
+		$response->status  = 'success';
+
+		$castos_handler = $this->createMock( \SeriouslySimplePodcasting\Handlers\Castos_Handler::class );
+		$castos_handler->method( 'connect' )->willReturn( $response );
+
+		$admin_notices_handler = $this->createMock( \SeriouslySimplePodcasting\Handlers\Admin_Notifications_Handler::class );
+		$admin_notices_handler->expects( $this->once() )
+			->method( 'remove_constant_notice' )
+			->with( \SeriouslySimplePodcasting\Handlers\Castos_Handler::DISCONNECT_NOTICE_KEY );
+
+		$handler       = new Ajax_Handler( $castos_handler, $admin_notices_handler );
+		$json_response = $this->capture_json_response( array( $handler, 'connect_castos' ) );
+
+		$this->assertSame( 'success', $json_response['status'] );
 	}
 
 	private function make_handler() {


### PR DESCRIPTION
## Summary
- Clear the Castos disconnect notice when the user successfully reconnects
- Add optional `$key` parameter to `add_constant_notice()` for deterministic notice identification
- Store disconnect notice under known key (`castos_disconnected`), remove by that key on reconnect
- Preserves original Castos API message as notice text

Closes CastosHQ/ssp-issues#844

## Test plan
- [ ] Simulate disconnect notice via WP-CLI or Castos dashboard disconnect
- [ ] Verify notice appears on SSP admin pages
- [ ] Reconnect via Podcasting > Settings > Hosting
- [ ] Verify disconnect notice disappears after successful reconnection
- [ ] Verify other constant notices (e.g. DB migration) are NOT affected
- [ ] Run `vendor/bin/codecept run WPUnit AjaxHandlerTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ability to specify a custom storage key for persistent admin notices.

* **Bug Fixes**
  * Castos disconnect notice is automatically cleared when users successfully reconnect.

* **Tests**
  * Added an AJAX test to verify the disconnect notice is removed on successful reconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->