### PR TITLE
Replace bare <image> in feed items with namespaced <ssp:image> #841

### DIFF
--- a/php/classes/handlers/class-feed-handler.php
+++ b/php/classes/handlers/class-feed-handler.php
@@ -516,7 +516,7 @@ class Feed_Handler implements Service {
 			return '';
 		}
 
-		return apply_filters( 'ssp_rss_stylesheet', $this->template_url . 'feed-stylesheet.xsl' );
+		return apply_filters( 'ssp_rss_stylesheet', $this->template_url . 'feed-stylesheet.xsl?v=2' );
 	}
 
 	/**

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -80,6 +80,7 @@ if ( $stylesheet_url ) {
 	 xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
 	 xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
 	 xmlns:podcast="https://podcastindex.org/namespace/1.0"
+	 xmlns:ssp="https://castos.com/seriously-simple-podcasting/namespace/1.0"
 	<?php do_action( 'rss2_ns' ); ?>>
 	<?php do_action( 'ssp_feed_before_channel_tag' ) ?>
 	<channel>

--- a/templates/feed-stylesheet.xsl
+++ b/templates/feed-stylesheet.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ssp="https://castos.com/seriously-simple-podcasting/namespace/1.0">
     <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
     <xsl:template match="/">
         <html xmlns="http://www.w3.org/1999/xhtml">
@@ -124,13 +124,13 @@
                                     <xsl:value-of select="title"/>
                                 </a>
                             </h2>
-							<xsl:if test="image">
+							<xsl:if test="ssp:image">
 							<img>
 								<xsl:attribute name="src">
-									<xsl:value-of select="image/url"/>
+									<xsl:value-of select="ssp:image/ssp:url"/>
 								</xsl:attribute>
 								<xsl:attribute name="title">
-									<xsl:value-of select="image/title"/>
+									<xsl:value-of select="ssp:image/ssp:title"/>
 								</xsl:attribute>
 							</img>
 							</xsl:if>

--- a/templates/feed/feed-item.php
+++ b/templates/feed/feed-item.php
@@ -67,10 +67,10 @@ if ( ! isset( $turbo_post_count ) || $turbo_post_count <= 10 ) : ?>
 
 if ( $episode_image ) : ?>
 	<itunes:image href="<?php echo esc_url( $episode_image ); ?>"></itunes:image>
-	<image>
-		<url><?php echo esc_url( $episode_image ); ?></url>
-		<title><?php echo esc_attr( $title ); ?></title>
-	</image>
+	<ssp:image>
+		<ssp:url><?php echo esc_url( $episode_image ); ?></ssp:url>
+		<ssp:title><?php echo esc_attr( $title ); ?></ssp:title>
+	</ssp:image>
 <?php endif;
 
 ?>

--- a/tests/Acceptance/3_main-feed.feature
+++ b/tests/Acceptance/3_main-feed.feature
@@ -27,7 +27,7 @@ Feature: Login
 
 		# Check XML elements
 		And I can see in source "<?xml version"
-		And I can see in source "<?xml-stylesheet type=\"text/xsl\" href=\"{{base_url}}/wp-content/plugins/seriously-simple-podcasting/templates/feed-stylesheet.xsl\"?>"
+		And I can see in source "<?xml-stylesheet type=\"text/xsl\" href=\"{{base_url}}/wp-content/plugins/seriously-simple-podcasting/templates/feed-stylesheet.xsl?v=2\"?>"
 		And I can see in source "<rss version=\"2.0\""
 		And I can see in source "xmlns:content=\"http://purl.org/rss/1.0/modules/content/\""
 		And I can see in source "xmlns:wfw=\"http://wellformedweb.org/CommentAPI/\""

--- a/tests/WPUnit/FeedControllerTest.php
+++ b/tests/WPUnit/FeedControllerTest.php
@@ -41,7 +41,7 @@ class FeedControllerTest extends \Codeception\TestCase\WPTestCase
 
         $test_parts = [
             '<?xml version="1.0" encoding="UTF-8"?>',
-            sprintf('<?xml-stylesheet type="text/xsl" href="%s/wp-content/plugins/seriously-simple-podcasting/templates/feed-stylesheet.xsl"?>', $site_url),
+            sprintf('<?xml-stylesheet type="text/xsl" href="%s/wp-content/plugins/seriously-simple-podcasting/templates/feed-stylesheet.xsl?v=2"?>', $site_url),
             '<rss version="2.0"',
             'xmlns:content="http://purl.org/rss/1.0/modules/content/"',
             'xmlns:wfw="http://wellformedweb.org/CommentAPI/"',
@@ -52,6 +52,7 @@ class FeedControllerTest extends \Codeception\TestCase\WPTestCase
             'xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"',
             'xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"',
             'xmlns:podcast="https://podcastindex.org/namespace/1.0"',
+            'xmlns:ssp="https://castos.com/seriously-simple-podcasting/namespace/1.0"',
             '<channel>',
             '<title>WordPress Test</title>',
             sprintf('<atom:link href="%s" rel="self" type="application/rss+xml"/>', trailingslashit( $site_url )),


### PR DESCRIPTION
## Summary
- Replace bare `<image>` element in feed items with namespaced `<ssp:image>` to fix RSS 2.0 validation and Spotify feed ingestion (#841)
- Declare `xmlns:ssp` namespace in the RSS root element
- Update XSL stylesheet to read from the namespaced element
- Add `?v=2` cache-buster to XSL stylesheet URL

## Test plan
- [ ] Visit feed URL in browser — episode artwork displays in human-readable view
- [ ] View raw feed XML — items contain `<ssp:image>`, no bare `<image>` in items
- [ ] Channel-level `<image>` is unchanged
- [ ] Validate feed at W3C RSS validator — no `<image>` errors in items


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * RSS stylesheet URL now includes a version parameter for improved cache handling.
  * Podcast feed declares a podcast-specific XML namespace for clearer metadata organization.
  * Podcast artwork metadata in feeds moved into the new namespace structure for better compatibility with podcast platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->