### PR TITLE
Sync image removal to Castos and add featured image filters

### DIFF
--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -754,7 +754,15 @@ class Frontend_Controller {
 		$image_url = '';
 		$image_id  = get_post_meta( $post_id, 'cover_image_id', true );
 
-		if ( ! $image_id ) {
+		/**
+		 * Controls whether the featured image is used as a fallback for feed/episode images.
+		 *
+		 * @param bool $use_featured Whether to use the featured image. Default true.
+		 * @param int  $post_id      The episode post ID.
+		 */
+		$use_featured_image = apply_filters( 'ssp_use_featured_image_for_feed', true, $post_id );
+
+		if ( ! $image_id && $use_featured_image ) {
 			$image_id = get_post_thumbnail_id( $post_id );
 		}
 

--- a/php/classes/handlers/class-castos-handler.php
+++ b/php/classes/handlers/class-castos-handler.php
@@ -393,9 +393,9 @@ class Castos_Handler implements Service {
 
 			$this->logger->log( 'API URL', $api_url );
 
-			$episode_image_url = $this->get_episode_image_url( $post );
-			if ( ! empty( $episode_image_url ) ) {
-				$post_body['featured_image_url'] = $episode_image_url;
+			$image_payload = $this->get_image_for_castos( $post, $podmotor_episode_id );
+			if ( $image_payload !== null ) {
+				$post_body['featured_image_url'] = $image_payload;
 			}
 
 			$this->logger->log( 'Post body', $post_body );
@@ -465,8 +465,18 @@ class Castos_Handler implements Service {
 		}
 
 		if ( ! $episode_image || ! $this->is_valid_episode_image( $attachment_id ) ) {
-			$episode_image = get_the_post_thumbnail_url( $post, 'full' );
-			$attachment_id = get_post_thumbnail_id( $post );
+			/**
+			 * Controls whether the featured image is used as a fallback for the Castos sync image.
+			 *
+			 * @param bool $use_featured Whether to use the featured image. Default true.
+			 * @param int  $episode_id   The episode post ID.
+			 */
+			$use_featured = apply_filters( 'ssp_use_featured_image_for_castos', true, $post->ID );
+
+			if ( $use_featured ) {
+				$episode_image = get_the_post_thumbnail_url( $post, 'full' );
+				$attachment_id = get_post_thumbnail_id( $post );
+			}
 		}
 
 		if ( ! $episode_image || ! $this->is_valid_episode_image( $attachment_id ) ) {
@@ -474,6 +484,40 @@ class Castos_Handler implements Service {
 		}
 
 		return $episode_image;
+	}
+
+	/**
+	 * Resolves the featured_image_url value for the Castos API payload.
+	 *
+	 * @param \WP_Post   $post                Post object.
+	 * @param string|int $podmotor_episode_id  Castos episode ID (empty for new episodes).
+	 *
+	 * @return string|null Image URL, empty string to clear, or null to omit the key.
+	 */
+	private function get_image_for_castos( $post, $podmotor_episode_id ) {
+		$image_url           = $this->get_episode_image_url( $post );
+		$is_existing_episode = ! empty( $podmotor_episode_id );
+
+		// Has a valid image — always send it
+		if ( ! empty( $image_url ) ) {
+			return $image_url;
+		}
+
+		// New episode — nothing to clear on Castos
+		if ( ! $is_existing_episode ) {
+			return null;
+		}
+
+		// Existing episode with no image — clear if allowed
+		/**
+		 * Controls whether SSP sends an empty image value to Castos to clear a stale image.
+		 *
+		 * @param bool $allow   Whether to allow image removal. Default true.
+		 * @param int  $post_id The episode post ID.
+		 */
+		$allow_removal = apply_filters( 'ssp_allow_castos_image_removal', true, $post->ID );
+
+		return $allow_removal ? '' : null;
 	}
 
 	/**

--- a/php/classes/repositories/class-episode-repository.php
+++ b/php/classes/repositories/class-episode-repository.php
@@ -859,12 +859,19 @@ class Episode_Repository implements Service {
 		/**
 		 * Option 5: if the post has a featured image, use that (no squareness check —
 		 * the HTML5 player handles non-square images via CSS)
+		 *
+		 * @param bool $use_featured Whether to use the featured image. Default true.
+		 * @param int  $episode_id   The episode post ID.
 		 */
-		$thumb_id = get_post_thumbnail_id( $episode_id );
-		if ( ! empty( $thumb_id ) ) {
-			$image_data_array = ssp_get_attachment_image_src( $thumb_id, $size );
-			if ( ! empty( $image_data_array['src'] ) ) {
-				return apply_filters( 'ssp_album_art', $image_data_array, $episode_id, $size, 'featured_image' );
+		$use_featured_image = apply_filters( 'ssp_use_featured_image_for_player', true, $episode_id );
+
+		if ( $use_featured_image ) {
+			$thumb_id = get_post_thumbnail_id( $episode_id );
+			if ( ! empty( $thumb_id ) ) {
+				$image_data_array = ssp_get_attachment_image_src( $thumb_id, $size );
+				if ( ! empty( $image_data_array['src'] ) ) {
+					return apply_filters( 'ssp_album_art', $image_data_array, $episode_id, $size, 'featured_image' );
+				}
 			}
 		}
 

--- a/tests/WPUnit/CastosHandlerImageTest.php
+++ b/tests/WPUnit/CastosHandlerImageTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Handlers\Castos_Handler;
+
+class CastosHandlerImageTest extends \Codeception\TestCase\WPTestCase
+{
+    /**
+     * @var Castos_Handler
+     */
+    protected $castos_handler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->castos_handler = ssp_get_service('castos_handler');
+    }
+
+    protected function tearDown(): void
+    {
+        remove_all_filters('ssp_use_featured_image_for_castos');
+        remove_all_filters('ssp_allow_castos_image_removal');
+        remove_all_filters('pre_http_request');
+        parent::tearDown();
+    }
+
+    /**
+     * Creates a test episode post.
+     *
+     * @return int Post ID.
+     */
+    protected function createEpisode()
+    {
+        return $this->factory()->post->create([
+            'post_status' => 'publish',
+            'post_type'   => SSP_CPT_PODCAST,
+        ]);
+    }
+
+    /**
+     * Creates an attachment post with image metadata.
+     *
+     * @param int $width  Image width.
+     * @param int $height Image height.
+     *
+     * @return int Attachment ID.
+     */
+    protected function createAttachment($width = 800, $height = 800)
+    {
+        $filename = 'test-image-' . wp_rand() . '.png';
+
+        $attachment_id = $this->factory()->attachment->create([
+            'post_mime_type' => 'image/png',
+            'post_type'     => 'attachment',
+        ]);
+
+        update_post_meta($attachment_id, '_wp_attached_file', $filename);
+        wp_update_attachment_metadata($attachment_id, [
+            'width'  => $width,
+            'height' => $height,
+            'file'   => $filename,
+            'sizes'  => [],
+        ]);
+
+        return $attachment_id;
+    }
+
+    /**
+     * @covers Castos_Handler::get_episode_image_url()
+     */
+    public function testReturnsEmptyWhenNoImageExists()
+    {
+        $episode_id = $this->createEpisode();
+        $post       = get_post($episode_id);
+
+        $result = $this->castos_handler->get_episode_image_url($post);
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @covers Castos_Handler::get_episode_image_url()
+     */
+    public function testReturnsCoverImageWhenSet()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(800, 800);
+        $post          = get_post($episode_id);
+
+        $image_url = wp_get_attachment_image_src($attachment_id, 'full')[0];
+        update_post_meta($episode_id, 'cover_image', $image_url);
+        update_post_meta($episode_id, 'cover_image_id', $attachment_id);
+
+        $result = $this->castos_handler->get_episode_image_url($post);
+
+        $this->assertSame($image_url, $result);
+    }
+
+    /**
+     * @covers Castos_Handler::get_episode_image_url()
+     */
+    public function testFallsBackToSquareFeaturedImage()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(800, 800);
+        $post          = get_post($episode_id);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        $result = $this->castos_handler->get_episode_image_url($post);
+
+        $featured_src = wp_get_attachment_image_src($attachment_id, 'full');
+        $this->assertSame($featured_src[0], $result);
+    }
+
+    /**
+     * @covers Castos_Handler::get_episode_image_url()
+     */
+    public function testSkipsNonSquareFeaturedImage()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(800, 600);
+        $post          = get_post($episode_id);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        $result = $this->castos_handler->get_episode_image_url($post);
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @covers Castos_Handler::get_episode_image_url()
+     */
+    public function testFilterDisablesFeaturedImageFallback()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(800, 800);
+        $post          = get_post($episode_id);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        add_filter('ssp_use_featured_image_for_castos', '__return_false');
+
+        $result = $this->castos_handler->get_episode_image_url($post);
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @covers Castos_Handler::get_episode_image_url()
+     */
+    public function testFilterReceivesEpisodeId()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(800, 800);
+        $post          = get_post($episode_id);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        $received_id = null;
+        add_filter('ssp_use_featured_image_for_castos', function ($use, $id) use (&$received_id) {
+            $received_id = $id;
+            return $use;
+        }, 10, 2);
+
+        $this->castos_handler->get_episode_image_url($post);
+
+        $this->assertSame($episode_id, $received_id);
+    }
+
+    /**
+     * @covers Castos_Handler::get_episode_image_url()
+     */
+    public function testFilterDoesNotAffectCoverImage()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(800, 800);
+        $post          = get_post($episode_id);
+
+        $image_url = wp_get_attachment_image_src($attachment_id, 'full')[0];
+        update_post_meta($episode_id, 'cover_image', $image_url);
+        update_post_meta($episode_id, 'cover_image_id', $attachment_id);
+
+        add_filter('ssp_use_featured_image_for_castos', '__return_false');
+
+        $result = $this->castos_handler->get_episode_image_url($post);
+
+        $this->assertSame($image_url, $result);
+    }
+
+    /**
+     * Sets up an existing episode with a podmotor_episode_id and file_id,
+     * intercepts the HTTP request, and returns the captured post body.
+     *
+     * @param int $episode_id Post ID.
+     *
+     * @return array|null Decoded JSON body from the intercepted request.
+     */
+    protected function captureUploadBody($episode_id)
+    {
+        update_post_meta($episode_id, 'podmotor_episode_id', 123);
+        update_post_meta($episode_id, 'podmotor_file_id', 456);
+        update_option('ss_podcasting_podmotor_account_api_token', 'test-token');
+
+        $captured_body = null;
+        add_filter('pre_http_request', function ($preempt, $args) use (&$captured_body) {
+            $captured_body = json_decode($args['body'], true);
+            return [
+                'response' => ['code' => 200, 'message' => 'OK'],
+                'body'     => wp_json_encode(['id' => 123, 'success' => true]),
+            ];
+        }, 10, 2);
+
+        $this->castos_handler->upload_episode_to_castos(get_post($episode_id));
+
+        return $captured_body;
+    }
+
+    /**
+     * @covers Castos_Handler::upload_episode_to_castos()
+     */
+    public function testUploadSendsEmptyImageUrlForExistingEpisode()
+    {
+        $episode_id = $this->createEpisode();
+        $body       = $this->captureUploadBody($episode_id);
+
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey('featured_image_url', $body);
+        $this->assertSame('', $body['featured_image_url']);
+    }
+
+    /**
+     * @covers Castos_Handler::upload_episode_to_castos()
+     */
+    public function testUploadOmitsEmptyImageUrlForNewEpisode()
+    {
+        $episode_id = $this->createEpisode();
+        update_post_meta($episode_id, 'podmotor_file_id', 456);
+        update_option('ss_podcasting_podmotor_account_api_token', 'test-token');
+
+        $captured_body = null;
+        add_filter('pre_http_request', function ($preempt, $args) use (&$captured_body) {
+            $captured_body = json_decode($args['body'], true);
+            return [
+                'response' => ['code' => 200, 'message' => 'OK'],
+                'body'     => wp_json_encode(['id' => 123, 'success' => true]),
+            ];
+        }, 10, 2);
+
+        $this->castos_handler->upload_episode_to_castos(get_post($episode_id));
+
+        $this->assertIsArray($captured_body);
+        $this->assertArrayNotHasKey('featured_image_url', $captured_body);
+    }
+
+    /**
+     * @covers Castos_Handler::upload_episode_to_castos()
+     */
+    public function testUploadRemovalFilterPreventsEmptyImageUrl()
+    {
+        $episode_id = $this->createEpisode();
+
+        add_filter('ssp_allow_castos_image_removal', '__return_false');
+
+        $body = $this->captureUploadBody($episode_id);
+
+        $this->assertIsArray($body);
+        $this->assertArrayNotHasKey('featured_image_url', $body);
+    }
+
+    /**
+     * @covers Castos_Handler::upload_episode_to_castos()
+     */
+    public function testUploadRemovalFilterReceivesEpisodeId()
+    {
+        $episode_id = $this->createEpisode();
+
+        $received_id = null;
+        add_filter('ssp_allow_castos_image_removal', function ($allow, $id) use (&$received_id) {
+            $received_id = $id;
+            return $allow;
+        }, 10, 2);
+
+        $this->captureUploadBody($episode_id);
+
+        $this->assertSame($episode_id, $received_id);
+    }
+}

--- a/tests/WPUnit/EpisodeRepositoryAlbumArtTest.php
+++ b/tests/WPUnit/EpisodeRepositoryAlbumArtTest.php
@@ -20,6 +20,7 @@ class EpisodeRepositoryAlbumArtTest extends \Codeception\TestCase\WPTestCase
 
     protected function tearDown(): void
     {
+        remove_all_filters('ssp_use_featured_image_for_player');
         parent::tearDown();
     }
 
@@ -134,5 +135,44 @@ class EpisodeRepositoryAlbumArtTest extends \Codeception\TestCase\WPTestCase
 
         $this->assertIsArray($result);
         $this->assertStringContainsString('no-album-art', $result['src']);
+    }
+
+    /**
+     * @covers Episode_Repository::get_album_art()
+     */
+    public function testFilterDisablesFeaturedImageFallback()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(1200, 800);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        add_filter('ssp_use_featured_image_for_player', '__return_false');
+
+        $result = $this->episode_repository->get_album_art($episode_id);
+
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('no-album-art', $result['src']);
+    }
+
+    /**
+     * @covers Episode_Repository::get_album_art()
+     */
+    public function testFilterReceivesEpisodeId()
+    {
+        $episode_id    = $this->createEpisode();
+        $attachment_id = $this->createAttachment(1200, 800);
+
+        set_post_thumbnail($episode_id, $attachment_id);
+
+        $received_id = null;
+        add_filter('ssp_use_featured_image_for_player', function ($use, $id) use (&$received_id) {
+            $received_id = $id;
+            return $use;
+        }, 10, 2);
+
+        $this->episode_repository->get_album_art($episode_id);
+
+        $this->assertSame($episode_id, $received_id);
     }
 }

--- a/tests/WPUnit/FrontendControllerTest.php
+++ b/tests/WPUnit/FrontendControllerTest.php
@@ -1135,8 +1135,121 @@ class FrontendControllerTest extends WPTestCase {
 		
 		// Clear validation cache to avoid test interference
 		$this->frontend_controller->clear_validation_cache();
-		
+
+		remove_all_filters('ssp_use_featured_image_for_feed');
+
 		parent::tearDown();
+	}
+
+	// ========================================
+	// SECTION: EPISODE IMAGE URL TESTS
+	// ========================================
+
+	/**
+	 * Creates a test episode post.
+	 *
+	 * @return int Post ID.
+	 */
+	protected function createEpisode() {
+		return $this->factory()->post->create( [
+			'post_status' => 'publish',
+			'post_type'   => SSP_CPT_PODCAST,
+		] );
+	}
+
+	/**
+	 * Creates an attachment post with image metadata.
+	 *
+	 * @param int $width  Image width.
+	 * @param int $height Image height.
+	 *
+	 * @return int Attachment ID.
+	 */
+	protected function createAttachment( $width = 800, $height = 800 ) {
+		$filename = 'test-image-' . wp_rand() . '.png';
+
+		$attachment_id = $this->factory()->attachment->create( [
+			'post_mime_type' => 'image/png',
+			'post_type'     => 'attachment',
+		] );
+
+		update_post_meta( $attachment_id, '_wp_attached_file', $filename );
+		wp_update_attachment_metadata( $attachment_id, [
+			'width'  => $width,
+			'height' => $height,
+			'file'   => $filename,
+			'sizes'  => [],
+		] );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * @covers Frontend_Controller::get_episode_image_url()
+	 */
+	public function testEpisodeImageReturnsFeaturedImageByDefault() {
+		$episode_id    = $this->createEpisode();
+		$attachment_id = $this->createAttachment( 800, 600 );
+
+		set_post_thumbnail( $episode_id, $attachment_id );
+
+		$result = $this->frontend_controller->get_episode_image_url( $episode_id );
+
+		$featured_src = wp_get_attachment_image_src( $attachment_id, 'full' );
+		$this->assertSame( $featured_src[0], $result );
+	}
+
+	/**
+	 * @covers Frontend_Controller::get_episode_image_url()
+	 */
+	public function testEpisodeImageFilterDisablesFeaturedImageFallback() {
+		$episode_id    = $this->createEpisode();
+		$attachment_id = $this->createAttachment( 800, 600 );
+
+		set_post_thumbnail( $episode_id, $attachment_id );
+
+		add_filter( 'ssp_use_featured_image_for_feed', '__return_false' );
+
+		$result = $this->frontend_controller->get_episode_image_url( $episode_id );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * @covers Frontend_Controller::get_episode_image_url()
+	 */
+	public function testEpisodeImageFilterReceivesEpisodeId() {
+		$episode_id    = $this->createEpisode();
+		$attachment_id = $this->createAttachment( 800, 600 );
+
+		set_post_thumbnail( $episode_id, $attachment_id );
+
+		$received_id = null;
+		add_filter( 'ssp_use_featured_image_for_feed', function ( $use, $id ) use ( &$received_id ) {
+			$received_id = $id;
+			return $use;
+		}, 10, 2 );
+
+		$this->frontend_controller->get_episode_image_url( $episode_id );
+
+		$this->assertSame( $episode_id, $received_id );
+	}
+
+	/**
+	 * @covers Frontend_Controller::get_episode_image_url()
+	 */
+	public function testEpisodeImageFilterDoesNotAffectCoverImage() {
+		$episode_id    = $this->createEpisode();
+		$attachment_id = $this->createAttachment( 800, 800 );
+
+		update_post_meta( $episode_id, 'cover_image_id', $attachment_id );
+
+		add_filter( 'ssp_use_featured_image_for_feed', '__return_false' );
+
+		$result = $this->frontend_controller->get_episode_image_url( $episode_id );
+
+		$cover_src = wp_get_attachment_image_src( $attachment_id, 'full' );
+		$this->assertSame( $cover_src[0], $result );
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix Castos sync to clear stale episode images when removed in SSP — previously the empty `featured_image_url` was omitted from the payload, so Castos kept the old image
- Add `ssp_use_featured_image_for_castos`, `ssp_use_featured_image_for_player`, and `ssp_use_featured_image_for_feed` filters (all default `true`) to control featured image fallback per path
- Add `ssp_allow_castos_image_removal` filter (default `true`) to control whether empty values clear images on Castos
- All filters receive `$episode_id` as second argument for per-episode control
- Extract image payload logic into `Castos_Handler::get_image_for_castos()` for clarity

## Test plan
- [ ] Remove episode-specific image on an existing episode, save — verify image is cleared on Castos
- [ ] Set a square featured image with no cover image — verify it syncs to Castos
- [ ] Add `add_filter('ssp_use_featured_image_for_castos', '__return_false')` — verify featured image is not synced
- [ ] Add `add_filter('ssp_allow_castos_image_removal', '__return_false')` — verify removing image does not clear on Castos
- [ ] Add `add_filter('ssp_use_featured_image_for_player', '__return_false')` — verify player shows placeholder instead of featured image
- [ ] Add `add_filter('ssp_use_featured_image_for_feed', '__return_false')` — verify feed item omits featured image
- [ ] Run full WPUnit suite — 264 tests pass

Closes CastosHQ/ssp-issues#849


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced filterable controls for episode image fallback behavior across feeds, player, and podcast hosting services.
  * Episodes can now conditionally use featured images as image sources based on context-specific filters.
  * Added control to manage image removal during podcast hosting synchronization.

* **Tests**
  * Added comprehensive test coverage for new image handling filters and fallback behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CastosHQ/Seriously-Simple-Podcasting/pull/901)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->