### PR TITLE
Update admin form control styles for WP 7.0 compatibility

### DIFF
--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -499,6 +499,10 @@ input:focus + .ssp-toggle__slider {
   margin: 5px 0 10px;
 }
 
+body.ssp-admin {
+  --wp-admin-theme-color: #853AED;
+}
+
 .ssp-admin {
   background-color: #F1F5F9;
   font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -627,6 +631,20 @@ input:focus + .ssp-toggle__slider {
 }
 .ssp-admin select:hover, .ssp-admin select:focus, .ssp-admin select option {
   color: #853AED;
+}
+.ssp-admin input[type=checkbox]:checked {
+  background: #853AED;
+  border-color: #853AED;
+}
+.ssp-admin input[type=checkbox]:checked::before {
+  content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%23ffffff%27%2F%3E%3C%2Fsvg%3E");
+}
+.ssp-admin input[type=radio]:checked {
+  background: #853AED;
+  border-color: #853AED;
+}
+.ssp-admin input[type=radio]:checked::before {
+  background-color: #FFFFFF;
 }
 .ssp-admin select:focus {
   border-color: #853AED;

--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -823,6 +823,22 @@ body.ssp-admin {
 .ssp-admin.post-type-podcast .ssp-dynamo__arrow-up::after {
   background: url("../img/arrow-up.svg");
 }
+.ssp-admin.podcast_page_podcast_settings .ssp-dynamo__container,
+.ssp-admin.podcast_page_podcast_settings .upsell-field__container {
+  background: #F5F0FF;
+}
+.ssp-admin.podcast_page_podcast_settings .ssp-dynamo__container::before,
+.ssp-admin.podcast_page_podcast_settings .upsell-field__container::before {
+  background: url("../img/stars-purple.svg");
+}
+.ssp-admin.podcast_page_podcast_settings .ssp-dynamo__btn,
+.ssp-admin.podcast_page_podcast_settings .upsell-field__btn {
+  border-color: #853AED;
+  color: #853AED;
+}
+.ssp-admin.podcast_page_podcast_settings .ssp-dynamo__arrow-up::after {
+  background: url("../img/arrow-up-purple.svg");
+}
 .ssp-admin #footer-left {
   font-size: 16px;
   margin-bottom: 20px;

--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -628,44 +628,10 @@ input:focus + .ssp-toggle__slider {
 .ssp-admin select:hover, .ssp-admin select:focus, .ssp-admin select option {
   color: #853AED;
 }
-.ssp-admin input[type=checkbox] {
-  width: 18px;
-  height: 18px;
-}
-.ssp-admin input[type=checkbox]:checked:before {
-  width: 22px;
-  content: url(data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%23853AED%27%2F%3E%3C%2Fsvg%3E);
-}
-.ssp-admin input[type=text]:focus,
-.ssp-admin input[type=password]:focus,
-.ssp-admin input[type=color]:focus,
-.ssp-admin input[type=date]:focus,
-.ssp-admin input[type=datetime]:focus,
-.ssp-admin input[type=datetime-local]:focus,
-.ssp-admin input[type=email]:focus,
-.ssp-admin input[type=month]:focus,
-.ssp-admin input[type=number]:focus,
-.ssp-admin input[type=search]:focus,
-.ssp-admin input[type=tel]:focus,
-.ssp-admin input[type=time]:focus,
-.ssp-admin input[type=url]:focus,
-.ssp-admin input[type=week]:focus,
-.ssp-admin input[type=checkbox]:focus,
-.ssp-admin input[type=radio]:focus,
-.ssp-admin select:focus,
-.ssp-admin textarea:focus {
+.ssp-admin select:focus {
   border-color: #853AED;
   box-shadow: 0 0 0 1px rgb(161.9395348837, 104.7302325581, 241.2697674419);
   outline: 1px solid transparent;
-}
-.ssp-admin input[type=radio]:checked::before {
-  content: "";
-  border-radius: 50%;
-  width: 0.5rem;
-  height: 0.5rem;
-  margin: 0.1875rem;
-  background-color: #853AED;
-  line-height: 1.14285714;
 }
 .ssp-admin input,
 .ssp-admin table.widefat,
@@ -768,10 +734,6 @@ input:focus + .ssp-toggle__slider {
 }
 .ssp-admin.post-type-podcast .components-button[aria-expanded=true] {
   color: #6C25D0;
-}
-.ssp-admin.post-type-podcast .components-checkbox-control__input[type=checkbox]:checked {
-  background-color: #853AED;
-  border-color: #853AED;
 }
 .ssp-admin.post-type-podcast .components-button.is-secondary:hover {
   color: #853AED;

--- a/assets/admin/scss/_ssp-admin.scss
+++ b/assets/admin/scss/_ssp-admin.scss
@@ -162,51 +162,12 @@
 		}
 	}
 
-	input[type="checkbox"] {
-		width: 18px;
-		height: 18px;
-
-		&:checked {
-			&:before {
-				width: 22px;
-				content: url(data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%23853AED%27%2F%3E%3C%2Fsvg%3E);
-			}
-		}
-	}
-
-	input[type="text"],
-	input[type="password"],
-	input[type="color"],
-	input[type="date"],
-	input[type="datetime"],
-	input[type="datetime-local"],
-	input[type="email"],
-	input[type="month"],
-	input[type="number"],
-	input[type="search"],
-	input[type="tel"],
-	input[type="time"],
-	input[type="url"],
-	input[type="week"],
-	input[type="checkbox"],
-	input[type="radio"],
-	select,
-	textarea {
+	select {
 		&:focus {
 			border-color: $clr_purple_600;
 			box-shadow: 0 0 0 1px lighten($clr_purple_600, 10%);
 			outline: 1px solid transparent;
 		}
-	}
-
-	input[type="radio"]:checked::before {
-		content: "";
-		border-radius: 50%;
-		width: 0.5rem;
-		height: 0.5rem;
-		margin: 0.1875rem;
-		background-color: $clr_purple_600;
-		line-height: 1.14285714;
 	}
 
 	input,
@@ -334,11 +295,6 @@
 
 			&-button[aria-expanded=true] {
 				color: $clr_purple_700;
-			}
-
-			&-checkbox-control__input[type="checkbox"]:checked {
-				background-color: $clr_purple_600;
-				border-color: $clr_purple_600;
 			}
 
 			&-button.is-secondary {

--- a/assets/admin/scss/_ssp-admin.scss
+++ b/assets/admin/scss/_ssp-admin.scss
@@ -1,5 +1,9 @@
 @import "mixins";
 
+body.ssp-admin {
+	--wp-admin-theme-color: #{$clr_purple_600};
+}
+
 .ssp-admin {
 	background-color: $clr_gray_100;
 	font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -159,6 +163,24 @@
 
 		&:hover, &:focus, option {
 			color: $clr_purple_600;
+		}
+	}
+
+	input[type="checkbox"]:checked {
+		background: $clr_purple_600;
+		border-color: $clr_purple_600;
+
+		&::before {
+			content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%23ffffff%27%2F%3E%3C%2Fsvg%3E");
+		}
+	}
+
+	input[type="radio"]:checked {
+		background: $clr_purple_600;
+		border-color: $clr_purple_600;
+
+		&::before {
+			background-color: $clr_white;
 		}
 	}
 

--- a/assets/admin/scss/_ssp-admin.scss
+++ b/assets/admin/scss/_ssp-admin.scss
@@ -416,6 +416,28 @@ body.ssp-admin {
 
 	}
 
+	&.podcast_page_podcast_settings {
+		.ssp-dynamo,
+		.upsell-field {
+			&__container {
+				background: #F5F0FF;
+
+				&::before {
+					background: url('../img/stars-purple.svg');
+				}
+			}
+
+			&__btn {
+				border-color: $clr_purple_600;
+				color: $clr_purple_600;
+			}
+		}
+
+		.ssp-dynamo__arrow-up::after {
+			background: url('../img/arrow-up-purple.svg');
+		}
+	}
+
 	#footer-left {
 		font-size: 16px;
 		margin-bottom: 20px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seriously-simple-podcasting",
-  "version": "3.16.0",
+  "version": "3.16.1-alpha",
   "main": "build/index.js",
   "author": "CastosHQ",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: PodcastMotor, psykro, zahardoc, simondowdles, hlashbrooke, whyisjake
 Tags: podcast, audio, itunes, podcasting, playlist
 Requires at least: 5.3
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 3.16.0
+Stable tag: 3.16.1-alpha
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -164,6 +164,11 @@ You can find complete user and developer documentation (along with the FAQs) on 
 15. View podcast episodes in the At A Glance widget on the main WordPress dashboard.
 
 == Changelog ==
+
+= 3.16.1-alpha =
+2026-05-21
+[UPDATE] Updated admin form controls (checkboxes, radio buttons) to use purple branding consistent with WordPress 7.0
+[UPDATE] Restyled Dynamo and upsell blocks to purple on the settings page
 
 = 3.16.0 =
 2026-05-20

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 3.16.0
+ * Version: 3.16.1-alpha
  * Plugin URI: https://castos.com/seriously-simple-podcasting/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
  * Author URI: https://castos.com/?utm_medium=sspodcasting&utm_source=wordpress&utm_campaign=wpplugin_08_2019
  * Requires PHP: 7.4
  * Requires at least: 5.3
- * Tested up to: 6.9
+ * Tested up to: 7.0
  *
  * Text Domain: seriously-simple-podcasting
  *
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SSP_VERSION', '3.16.0' );
+define( 'SSP_VERSION', '3.16.1-alpha' );
 define( 'SSP_PLUGIN_FILE', __FILE__ );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## Summary
- Replaced custom purple checkbox/radio overrides that clashed with WP 7.0's new admin UI with `--wp-admin-theme-color` CSS variable override and explicit purple background + white checkmark/dot styles that work on both WP 6.7 and 7.0
- Restyled Dynamo and upsell blocks to purple on the settings page (scoped via `podcast_page_podcast_settings` body class so episode edit page stays unchanged)
- Bumped version to 3.16.1-alpha, updated Tested up to 7.0

## Test plan
- [ ] On WP 7.0: verify checkboxes and radio buttons on Settings > General have purple background with white checkmark/dot
- [ ] On WP 7.0: verify Save Settings button remains purple
- [ ] On WP 7.0: verify links, nav tabs, and "Add New" button remain purple
- [ ] On WP 7.0: verify select dropdowns retain purple focus ring
- [ ] On WP 6.7: verify checkboxes and radio buttons also show purple styling
- [ ] On Settings > Feed Details: verify Dynamo block has purple stars, button, and arrow
- [ ] On Episode edit page: verify Dynamo block stays blue (unchanged)
- [ ] Verify no visual regressions on other SSP admin pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Admin interface updated with purple branding aligned with WordPress 7.0 compatibility
  * Form controls restyled, including improved checkbox, radio button, and select input focus states
  * Podcast settings page enhanced with new visual styling and design elements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CastosHQ/Seriously-Simple-Podcasting/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->