### PR TITLE
Fix player Share link showing unpretty URL for non-podcast post types

### DIFF
--- a/php/classes/repositories/class-episode-repository.php
+++ b/php/classes/repositories/class-episode-repository.php
@@ -638,7 +638,7 @@ class Episode_Repository implements Service {
 			$episode          = isset( $post ) ? $post : get_post( $id );
 			$current_post     = $current_post ?: $episode;
 			$episode_duration = get_post_meta( $id, 'duration', true );
-			$current_url      = get_post_permalink( $current_post->ID );
+			$current_url      = get_permalink( $current_post->ID );
 
 			if ( ssp_episode_passthrough_required( $id ) ) {
 				$audio_file = $this->get_passthrough_url( $id );


### PR DESCRIPTION
## Summary
- The SSP player Share link (copy-link input + Facebook/Twitter share hrefs) showed the plain `?post_type=post&p=ID` URL for episodes using the built-in `post` type, instead of the pretty permalink shown for the `podcast` post type.
- Root cause: `Episode_Repository::get_player_data()` built `current_url` with `get_post_permalink()`, which only resolves pretty URLs via the CPT extra permastruct — the built-in `post` type has none, so it fell back to the query-arg form.
- Switched to `get_permalink()`, which dispatches per post type: pretty URLs for `post` (and pages/attachments), and identical output for the `podcast` CPT (routed through the same internal path), so no regression.
- Fixes CastosHQ/ssp-issues#853.

## Test plan
- [ ] On a `post`-type episode page, open the player Share panel — copy-link input and FB/Twitter hrefs show the pretty permalink.
- [ ] On a `podcast`-type episode, confirm the Share link is unchanged (still pretty).
- [ ] CI: PHPCS + WPUnit pass (PHPCS could not run locally — ruleset references uninstalled PHPCompatibilityWP).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL generation for player functionality to use a more reliable method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->