### PR TITLE
Write enclosure post meta in WordPress standard format

### DIFF
--- a/php/classes/controllers/class-podcast-post-types-controller.php
+++ b/php/classes/controllers/class-podcast-post-types-controller.php
@@ -583,9 +583,10 @@ class Podcast_Post_Types_Controller {
 		}
 
 		// Save podcast file to the 'enclosure' meta field (WP-standard format) for standards-sake.
-		// Uses the size already stored in meta; for Castos sites this is the value the REST sync
-		// callback later refreshes, for self-hosted it is refreshed below once filesize_raw is known.
-		$this->update_enclosure_meta( $post_id, $enclosure );
+		// When the URL changed, force size 0 so the previous file's size is not paired with the new
+		// URL; self-hosted refreshes it below once filesize_raw is recalculated, and the Castos REST
+		// sync callback refreshes it for Castos sites.
+		$this->update_enclosure_meta( $post_id, $enclosure, $is_enclosure_updated ? 0 : null );
 
 		// Only process file metadata if not connected to Castos
 		if ( ssp_is_connected_to_castos() ) {
@@ -617,7 +618,7 @@ class Podcast_Post_Types_Controller {
 					update_post_meta( $post_id, 'filesize_raw', $filesize['raw'] );
 
 					// Refresh the enclosure meta now that the real file size is known.
-					$this->update_enclosure_meta( $post_id, $enclosure );
+					$this->update_enclosure_meta( $post_id, $enclosure, $filesize['raw'] );
 				}
 			}
 		}
@@ -626,16 +627,21 @@ class Podcast_Post_Types_Controller {
 	/**
 	 * Writes the 'enclosure' meta in WordPress's standard "url\nsize\nmime\n" format.
 	 *
-	 * Pulls the raw size from the filesize_raw meta (populated for both self-hosted
-	 * and Castos episodes), so the value stays parseable by external podcasting tools.
+	 * When $size is null, falls back to the stored filesize_raw meta (populated for both
+	 * self-hosted and Castos episodes). Callers pass an explicit size to avoid pairing a
+	 * stale size with a changed URL, keeping the value parseable by external podcasting tools.
 	 *
-	 * @param int    $post_id Episode post ID.
-	 * @param string $url     Enclosure file URL.
+	 * @param int             $post_id Episode post ID.
+	 * @param string          $url     Enclosure file URL.
+	 * @param int|string|null $size    Raw file size; null reads it from the filesize_raw meta.
 	 *
 	 * @return void
 	 */
-	protected function update_enclosure_meta( $post_id, $url ) {
-		$size      = get_post_meta( $post_id, 'filesize_raw', true );
+	protected function update_enclosure_meta( $post_id, $url, $size = null ) {
+		if ( null === $size ) {
+			$size = get_post_meta( $post_id, 'filesize_raw', true );
+		}
+
 		$enclosure = $this->episode_repository->format_enclosure( $url, $size );
 		update_post_meta( $post_id, 'enclosure', $enclosure );
 	}

--- a/php/classes/controllers/class-podcast-post-types-controller.php
+++ b/php/classes/controllers/class-podcast-post-types-controller.php
@@ -582,8 +582,10 @@ class Podcast_Post_Types_Controller {
 			update_post_meta( $post_id, 'date_recorded', $post->post_date );
 		}
 
-		// Save podcast file to 'enclosure' meta field for standards-sake
-		update_post_meta( $post_id, 'enclosure', $enclosure );
+		// Save podcast file to the 'enclosure' meta field (WP-standard format) for standards-sake.
+		// Uses the size already stored in meta; for Castos sites this is the value the REST sync
+		// callback later refreshes, for self-hosted it is refreshed below once filesize_raw is known.
+		$this->update_enclosure_meta( $post_id, $enclosure );
 
 		// Only process file metadata if not connected to Castos
 		if ( ssp_is_connected_to_castos() ) {
@@ -603,7 +605,7 @@ class Podcast_Post_Types_Controller {
 		// If either is missing, recalculate both to avoid mixing frontend/backend data
 		$has_filesize     = get_post_meta( $post_id, 'filesize', true ) != '';
 		$has_filesize_raw = get_post_meta( $post_id, 'filesize_raw', true ) != '';
-		
+
 		if ( $is_enclosure_updated || ! $has_filesize || ! $has_filesize_raw ) {
 			$filesize = $this->episode_repository->get_file_size( $enclosure );
 			if ( $filesize ) {
@@ -613,9 +615,29 @@ class Podcast_Post_Types_Controller {
 
 				if ( isset( $filesize['raw'] ) ) {
 					update_post_meta( $post_id, 'filesize_raw', $filesize['raw'] );
+
+					// Refresh the enclosure meta now that the real file size is known.
+					$this->update_enclosure_meta( $post_id, $enclosure );
 				}
 			}
 		}
+	}
+
+	/**
+	 * Writes the 'enclosure' meta in WordPress's standard "url\nsize\nmime\n" format.
+	 *
+	 * Pulls the raw size from the filesize_raw meta (populated for both self-hosted
+	 * and Castos episodes), so the value stays parseable by external podcasting tools.
+	 *
+	 * @param int    $post_id Episode post ID.
+	 * @param string $url     Enclosure file URL.
+	 *
+	 * @return void
+	 */
+	protected function update_enclosure_meta( $post_id, $url ) {
+		$size      = get_post_meta( $post_id, 'filesize_raw', true );
+		$enclosure = $this->episode_repository->format_enclosure( $url, $size );
+		update_post_meta( $post_id, 'enclosure', $enclosure );
 	}
 
 	/**

--- a/php/classes/handlers/class-upgrade-handler.php
+++ b/php/classes/handlers/class-upgrade-handler.php
@@ -107,6 +107,7 @@ class Upgrade_Handler implements Service {
 
 		if ( version_compare( $previous_version, '3.16.2', '<' ) ) {
 			$this->cleanup_duplicate_guids_options();
+			$this->format_enclosures();
 			// ssp_db_version is defunct after DB_Migration_Controller was removed in 3.16.2.
 			delete_option( 'ssp_db_version' );
 		}
@@ -278,6 +279,36 @@ class Upgrade_Handler implements Service {
 		$this->episode_repository->update_failed_sync_episodes_option( array_values( $episodes ) );
 	}
 
+
+	/**
+	 * Rewrites legacy bare-URL `enclosure` meta into WordPress's standard
+	 * "url\nsize\nmime\n" format so WP core rss_enclosure() and other podcasting
+	 * plugins can parse it. Size comes from the stored filesize_raw meta. (#855)
+	 *
+	 * @return void
+	 */
+	public function format_enclosures() {
+		ignore_user_abort( true );
+
+		/**
+		 * @var Episode_Repository $episode_repository
+		 * */
+		$episode_repository = ssp_get_service( 'episode_repository' );
+
+		foreach ( ssp_episode_ids() as $episode_id ) {
+			$url = $episode_repository->get_enclosure( $episode_id );
+			if ( ! $url ) {
+				continue;
+			}
+
+			$size      = get_post_meta( $episode_id, 'filesize_raw', true );
+			$formatted = $episode_repository->format_enclosure( $url, $size );
+
+			if ( get_post_meta( $episode_id, 'enclosure', true ) !== $formatted ) {
+				update_post_meta( $episode_id, 'enclosure', $formatted );
+			}
+		}
+	}
 
 	/**
 	 * Update enclosures to remove AWS file references.

--- a/php/classes/repositories/class-episode-repository.php
+++ b/php/classes/repositories/class-episode-repository.php
@@ -1147,6 +1147,49 @@ class Episode_Repository implements Service {
 	}
 
 	/**
+	 * Builds the WordPress-standard enclosure meta value: "url\nsize\nmime\n".
+	 *
+	 * Mirrors core do_enclose() so the `enclosure` meta stays parseable by WP core's
+	 * rss_enclosure() and by other podcasting plugins. The size is always numeric
+	 * (0 when unknown) and the MIME type is always derived from the file extension,
+	 * so the value always carries three newline-separated parts.
+	 *
+	 * @param string     $url  Enclosure file URL.
+	 * @param int|string $size Raw file size in bytes; 0/empty when unknown.
+	 * @param string     $mime Optional MIME type; derived from the URL when empty.
+	 *
+	 * @return string Formatted enclosure value, or empty string when no URL is given.
+	 */
+	public function format_enclosure( $url, $size = 0, $mime = '' ) {
+		if ( ! $url ) {
+			return '';
+		}
+
+		if ( ! $mime ) {
+			$mime = $this->get_file_mime_type( $url );
+		}
+
+		return $url . "\n" . intval( $size ) . "\n" . $mime . "\n";
+	}
+
+	/**
+	 * Derives a MIME type from a file URL's extension, defaulting to audio/mpeg.
+	 *
+	 * Keeps the enclosure value's third part non-empty even for URLs WordPress
+	 * can't map, matching the audio-first default of Feed_Handler::get_feed_item_mime_type().
+	 *
+	 * @param string $url File URL.
+	 *
+	 * @return string MIME type.
+	 */
+	public function get_file_mime_type( $url ) {
+		$filetype = wp_check_filetype( $url );
+		$mime     = empty( $filetype['type'] ) ? '' : $filetype['type'];
+
+		return apply_filters( 'ssp_enclosure_mime_type', $mime ? $mime : 'audio/mpeg', $url );
+	}
+
+	/**
 	 * Returns a local file path for the given file URL if it's local. Otherwise
 	 * returns the original URL
 	 *

--- a/php/classes/rest/class-episodes-rest-controller.php
+++ b/php/classes/rest/class-episodes-rest-controller.php
@@ -254,8 +254,15 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 
 				update_post_meta( $episode_id, $audio_file_meta_key, $new_data['file']['url'] );
 
-				// Also, update 'enclosure' field for easy moving from/to other plugins
-				update_post_meta( $episode_id, 'enclosure', $new_data['file']['url'] );
+				// Also, update the 'enclosure' field (WP-standard "url\nsize\nmime\n" format) for
+				// easy moving from/to other plugins. Size/MIME come from the Castos payload when
+				// present, falling back to the stored filesize_raw meta, then 0 + extension MIME.
+				$file_size = ! empty( $new_data['file']['size'] )
+					? $new_data['file']['size']
+					: get_post_meta( $episode_id, 'filesize_raw', true );
+				$mime_type = empty( $new_data['file']['mime_type'] ) ? '' : $new_data['file']['mime_type'];
+				$enclosure = $this->episode_repository->format_enclosure( $new_data['file']['url'], $file_size, $mime_type );
+				update_post_meta( $episode_id, 'enclosure', $enclosure );
 			}
 
 			// Update Castos episode ID

--- a/tests/WPUnit/EnclosureMetaWriteTest.php
+++ b/tests/WPUnit/EnclosureMetaWriteTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Rest\Episodes_Rest_Controller;
+
+class EnclosureMetaWriteTest extends \Codeception\TestCase\WPTestCase {
+
+	protected function createEpisode() {
+		return $this->factory()->post->create( array(
+			'post_status' => 'publish',
+			'post_type'   => SSP_CPT_PODCAST,
+		) );
+	}
+
+	/**
+	 * Save path: the post-types controller writes the enclosure in WP-standard format
+	 * using the stored filesize_raw meta.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Controllers\Podcast_Post_Types_Controller::update_enclosure_meta
+	 */
+	public function testSavePathWritesFormattedEnclosureFromFilesizeRaw() {
+		$episode_id = $this->createEpisode();
+		update_post_meta( $episode_id, 'filesize_raw', 54321 );
+
+		$controller = ssp_app()->podcast_post_types_controller;
+		$method     = new \ReflectionMethod( $controller, 'update_enclosure_meta' );
+		$method->setAccessible( true );
+		$method->invoke( $controller, $episode_id, 'https://example.com/episode.mp3' );
+
+		$this->assertSame(
+			"https://example.com/episode.mp3\n54321\naudio/mpeg\n",
+			get_post_meta( $episode_id, 'enclosure', true )
+		);
+	}
+
+	/**
+	 * Castos sync path: the REST callback writes the enclosure in WP-standard format,
+	 * falling back to the stored filesize_raw meta when the payload carries no size.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Rest\Episodes_Rest_Controller::update_episode
+	 */
+	public function testCastosSyncWritesFormattedEnclosureWithFilesizeRawFallback() {
+		$episode_id = $this->createEpisode();
+		update_post_meta( $episode_id, 'filesize_raw', 88888 );
+
+		$controller = new Episodes_Rest_Controller( ssp_episode_repository() );
+
+		$request = new \WP_REST_Request( 'PUT', '/ssp/v1/episodes/' . $episode_id );
+		$request->set_url_params( array( 'episode_id' => $episode_id ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array(
+			'file'    => array(
+				'id'  => 123,
+				'url' => 'https://episodes.castos.com/show.mp3',
+			),
+			'episode' => array( 'id' => 456 ),
+		) ) );
+
+		$controller->update_episode( $request );
+
+		$this->assertSame(
+			"https://episodes.castos.com/show.mp3\n88888\naudio/mpeg\n",
+			get_post_meta( $episode_id, 'enclosure', true )
+		);
+	}
+
+	/**
+	 * Castos sync path: size and MIME from the payload take precedence over the fallback.
+	 *
+	 * @covers \SeriouslySimplePodcasting\Rest\Episodes_Rest_Controller::update_episode
+	 */
+	public function testCastosSyncPrefersPayloadSizeAndMime() {
+		$episode_id = $this->createEpisode();
+		update_post_meta( $episode_id, 'filesize_raw', 1 );
+
+		$controller = new Episodes_Rest_Controller( ssp_episode_repository() );
+
+		$request = new \WP_REST_Request( 'PUT', '/ssp/v1/episodes/' . $episode_id );
+		$request->set_url_params( array( 'episode_id' => $episode_id ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array(
+			'file'    => array(
+				'id'        => 123,
+				'url'       => 'https://episodes.castos.com/show.mp4',
+				'size'      => 777777,
+				'mime_type' => 'video/mp4',
+			),
+			'episode' => array( 'id' => 456 ),
+		) ) );
+
+		$controller->update_episode( $request );
+
+		$this->assertSame(
+			"https://episodes.castos.com/show.mp4\n777777\nvideo/mp4\n",
+			get_post_meta( $episode_id, 'enclosure', true )
+		);
+	}
+}

--- a/tests/WPUnit/EpisodeRepositoryEnclosureTest.php
+++ b/tests/WPUnit/EpisodeRepositoryEnclosureTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Repositories\Episode_Repository;
+
+class EpisodeRepositoryEnclosureTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @var Episode_Repository
+	 */
+	protected $episode_repository;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->episode_repository = ssp_get_service( 'episode_repository' );
+	}
+
+	/**
+	 * @covers Episode_Repository::format_enclosure
+	 */
+	public function testFormatEnclosureProducesThreeNewlineSeparatedParts() {
+		$value = $this->episode_repository->format_enclosure( 'https://example.com/episode.mp3', 12345, 'audio/mpeg' );
+
+		$this->assertSame( "https://example.com/episode.mp3\n12345\naudio/mpeg\n", $value );
+
+		// Mirrors WP core rss_enclosure()/PowerPress parsing: explode keeps url/size/mime in order.
+		$parts = explode( "\n", $value );
+		$this->assertSame( 'https://example.com/episode.mp3', $parts[0] );
+		$this->assertSame( '12345', $parts[1] );
+		$this->assertSame( 'audio/mpeg', $parts[2] );
+	}
+
+	/**
+	 * @covers Episode_Repository::format_enclosure
+	 */
+	public function testFormatEnclosureCastsSizeToIntAndDefaultsToZero() {
+		$this->assertSame( "https://example.com/e.mp3\n0\naudio/mpeg\n", $this->episode_repository->format_enclosure( 'https://example.com/e.mp3', '' ) );
+		$this->assertSame( "https://example.com/e.mp3\n999\naudio/mpeg\n", $this->episode_repository->format_enclosure( 'https://example.com/e.mp3', '999' ) );
+	}
+
+	/**
+	 * @covers Episode_Repository::format_enclosure
+	 */
+	public function testFormatEnclosureDerivesMimeFromExtensionWhenNotProvided() {
+		$audio = $this->episode_repository->format_enclosure( 'https://example.com/show.mp3', 1 );
+		$video = $this->episode_repository->format_enclosure( 'https://example.com/show.mp4', 1 );
+
+		$this->assertSame( 'audio/mpeg', explode( "\n", $audio )[2] );
+		$this->assertSame( 'video/mp4', explode( "\n", $video )[2] );
+	}
+
+	/**
+	 * @covers Episode_Repository::get_file_mime_type
+	 */
+	public function testMimeTypeDefaultsToAudioForUnknownExtension() {
+		$this->assertSame( 'audio/mpeg', $this->episode_repository->get_file_mime_type( 'https://example.com/file.unknownext' ) );
+	}
+
+	/**
+	 * @covers Episode_Repository::get_file_mime_type
+	 */
+	public function testMimeTypeFilterCanOverrideDerivedValue() {
+		add_filter( 'ssp_enclosure_mime_type', function () {
+			return 'audio/x-custom';
+		} );
+
+		$this->assertSame( 'audio/x-custom', $this->episode_repository->get_file_mime_type( 'https://example.com/file.mp3' ) );
+
+		remove_all_filters( 'ssp_enclosure_mime_type' );
+	}
+
+	/**
+	 * @covers Episode_Repository::format_enclosure
+	 */
+	public function testFormatEnclosureReturnsEmptyStringForEmptyUrl() {
+		$this->assertSame( '', $this->episode_repository->format_enclosure( '', 100, 'audio/mpeg' ) );
+	}
+}

--- a/tests/WPUnit/PodcastPostTypesControllerTest.php
+++ b/tests/WPUnit/PodcastPostTypesControllerTest.php
@@ -64,6 +64,14 @@ class PodcastPostTypesControllerTest extends \Codeception\TestCase\WPTestCase
         $this->mock_episode_repository = $this->createMock(Episode_Repository::class);
         $mock_series_handler = $this->createMock(Series_Handler::class);
 
+        // Mirror the real Episode_Repository::format_enclosure() so the controller stores a
+        // WP-standard "url\nsize\nmime\n" value (the mocked repository would otherwise return null).
+        $this->mock_episode_repository
+            ->method('format_enclosure')
+            ->willReturnCallback(function ($url, $size = 0, $mime = '') {
+                return $url ? $url . "\n" . intval($size) . "\n" . ($mime ?: 'audio/mpeg') . "\n" : '';
+            });
+
         // Create controller instance with all required dependencies
         $this->controller = new Podcast_Post_Types_Controller(
             $mock_cpt_podcast_handler,
@@ -124,7 +132,8 @@ class PodcastPostTypesControllerTest extends \Codeception\TestCase\WPTestCase
         $this->controller->handle_enclosure_update($post, $new_enclosure);
 
         // Assertions
-        $this->assertEquals($new_enclosure, get_post_meta($this->post_id, 'enclosure', true));
+        // Enclosure is refreshed after filesize_raw is calculated, so it carries the real size.
+        $this->assertEquals("$new_enclosure\n5452595\naudio/mpeg\n", get_post_meta($this->post_id, 'enclosure', true));
         $this->assertEquals('2024-01-01 12:00:00', get_post_meta($this->post_id, 'date_recorded', true));
         $this->assertEquals('00:05:30', get_post_meta($this->post_id, 'duration', true));
         $this->assertEquals('5.2 MB', get_post_meta($this->post_id, 'filesize', true));
@@ -150,7 +159,8 @@ class PodcastPostTypesControllerTest extends \Codeception\TestCase\WPTestCase
         $this->controller->handle_enclosure_update($post, $enclosure);
 
         // Assertions
-        $this->assertEquals($enclosure, get_post_meta($this->post_id, 'enclosure', true));
+        // No filesize_raw available, so size defaults to 0 in the formatted value.
+        $this->assertEquals("$enclosure\n0\naudio/mpeg\n", get_post_meta($this->post_id, 'enclosure', true));
         // date_recorded should not change since enclosure didn't change
         $this->assertEquals('2023-12-01 10:00:00', get_post_meta($this->post_id, 'date_recorded', true));
     }
@@ -179,7 +189,8 @@ class PodcastPostTypesControllerTest extends \Codeception\TestCase\WPTestCase
         $this->controller->handle_enclosure_update($post, $new_enclosure);
 
         // Assertions
-        $this->assertEquals($new_enclosure, get_post_meta($this->post_id, 'enclosure', true));
+        // Castos path writes the enclosure before the early return; size unknown here, so 0.
+        $this->assertEquals("$new_enclosure\n0\naudio/mpeg\n", get_post_meta($this->post_id, 'enclosure', true));
         $this->assertEquals('2024-01-01 12:00:00', get_post_meta($this->post_id, 'date_recorded', true));
         // File metadata should not be updated when connected to Castos
         $this->assertEmpty(get_post_meta($this->post_id, 'duration', true));
@@ -236,7 +247,8 @@ class PodcastPostTypesControllerTest extends \Codeception\TestCase\WPTestCase
         $this->controller->handle_enclosure_update($post, $new_enclosure);
 
         // Assertions
-        $this->assertEquals($new_enclosure, get_post_meta($this->post_id, 'enclosure', true));
+        // get_file_size returns false, so no filesize_raw and size stays 0 in the formatted value.
+        $this->assertEquals("$new_enclosure\n0\naudio/mpeg\n", get_post_meta($this->post_id, 'enclosure', true));
         // Duration should still be updated
         $this->assertEquals('00:05:30', get_post_meta($this->post_id, 'duration', true));
         // Filesize should not be updated if repository returns false
@@ -275,7 +287,8 @@ class PodcastPostTypesControllerTest extends \Codeception\TestCase\WPTestCase
         $this->controller->handle_enclosure_update($post, $new_enclosure);
 
         // Assertions
-        $this->assertEquals($new_enclosure, get_post_meta($this->post_id, 'enclosure', true));
+        // filesize_raw not provided (no 'raw' key), so size stays 0 in the formatted value.
+        $this->assertEquals("$new_enclosure\n0\naudio/mpeg\n", get_post_meta($this->post_id, 'enclosure', true));
         $this->assertEquals('00:05:30', get_post_meta($this->post_id, 'duration', true));
         $this->assertEquals('5.2 MB', get_post_meta($this->post_id, 'filesize', true));
         // filesize_raw should not be set if not provided

--- a/tests/WPUnit/PodcastPostTypesControllerTest.php
+++ b/tests/WPUnit/PodcastPostTypesControllerTest.php
@@ -257,6 +257,35 @@ class PodcastPostTypesControllerTest extends \Codeception\TestCase\WPTestCase
     }
 
     /**
+     * Test that a changed URL does not inherit the previous file's size in the enclosure
+     * when the new file's size cannot be fetched (would otherwise serialize a stale size).
+     */
+    public function testHandleEnclosureUpdateResetsStaleSizeOnUrlChangeWhenFilesizeFails()
+    {
+        $post = get_post($this->post_id);
+        $old_enclosure = 'https://example.com/old-audio.mp3';
+        $new_enclosure = 'https://example.com/new-audio.mp3';
+
+        // Existing state: old URL with a known (now stale) size.
+        update_post_meta($this->post_id, 'audio_file', $old_enclosure);
+        update_post_meta($this->post_id, 'filesize_raw', 9999999);
+
+        // New file's size lookup fails.
+        $this->mock_episode_repository
+            ->expects($this->once())
+            ->method('get_file_size')
+            ->with($new_enclosure)
+            ->willReturn(false);
+
+        $this->mock_function('ssp_is_connected_to_castos', false);
+
+        $this->controller->handle_enclosure_update($post, $new_enclosure);
+
+        // Enclosure must pair the new URL with size 0, not the old file's 9999999.
+        $this->assertEquals("$new_enclosure\n0\naudio/mpeg\n", get_post_meta($this->post_id, 'enclosure', true));
+    }
+
+    /**
      * Test handle_enclosure_update with partial filesize data.
      */
     public function testHandleEnclosureUpdateWithPartialFilesizeData()

--- a/tests/WPUnit/UpgradeHandlerTest.php
+++ b/tests/WPUnit/UpgradeHandlerTest.php
@@ -38,4 +38,27 @@ class UpgradeHandlerTest extends \Codeception\TestCase\WPTestCase
             $this->assertEquals($expected, $updated);
         }
     }
+
+    /**
+     * @covers \SeriouslySimplePodcasting\Handlers\Upgrade_Handler::format_enclosures
+     */
+    public function testFormatEnclosuresBackfillsLegacyBareUrlMeta()
+    {
+        $episode_id = $this->factory()->post->create([
+            'post_status' => 'publish',
+            'post_type'   => SSP_CPT_PODCAST,
+        ]);
+
+        // Legacy state: audio_file holds the URL, enclosure is a bare URL, size is known.
+        update_post_meta($episode_id, 'audio_file', 'https://episodes.castos.com/show.mp3');
+        update_post_meta($episode_id, 'enclosure', 'https://episodes.castos.com/show.mp3');
+        update_post_meta($episode_id, 'filesize_raw', 24680);
+
+        $this->upgrade_handler->format_enclosures();
+
+        $this->assertEquals(
+            "https://episodes.castos.com/show.mp3\n24680\naudio/mpeg\n",
+            get_post_meta($episode_id, 'enclosure', true)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- SSP wrote a bare URL to the `enclosure` post meta. WP core `rss_enclosure()` silently skips entries with fewer than 3 parts, and plugins that parse the standard 3-part value emitted PHP warnings.
- Add `Episode_Repository::format_enclosure()` (plus `get_file_mime_type()`, filterable via `ssp_enclosure_mime_type`) producing the WP-standard `"$url\n$size\n$mime\n"` — size is always numeric (`0` when unknown), MIME is always derived from the file extension, so the value always carries three parts.
- Write the formatted value at both sites: episode save (`handle_enclosure_update()`, refreshed after `filesize_raw` is computed) and the Castos sync callback (`update_episode()`, using payload size/MIME when present, else the `filesize_raw` meta, else `0` + extension MIME).
- Backfill existing episodes via `Upgrade_Handler::format_enclosures()`, hooked into the `< 3.16.2` upgrade block.
- The `enclosure` meta exists for cross-plugin compatibility only — SSP reads its file URL from the `audio_file` meta via `get_enclosure()`, so no internal behavior changes.
- Verified the format parses positionally (url/size/mime) in PowerPress and SSP Administration readers; the optional serialized 4th part is absent and tolerated.

Issue: CastosHQ/ssp-issues#855

## Test plan
- [ ] WPUnit passes: `EpisodeRepositoryEnclosureTest`, `EnclosureMetaWriteTest`, `UpgradeHandlerTest`, `PodcastPostTypesControllerTest`
- [ ] Saving a self-hosted episode writes `url\nsize\nmime` to the `enclosure` meta with the real file size
- [ ] Castos sync callback writes the formatted value (size from the `filesize_raw` fallback when the payload omits it)
- [ ] Upgrade backfill reformats existing episodes' `enclosure` meta (verified across 28 episodes locally)
- [ ] Resulting value reads cleanly via WP core `rss_enclosure()` and other podcasting plugins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Legacy podcast episode enclosure metadata using bare URLs is now automatically backfilled to the WordPress-standard enclosure format during upgrade.

* **Improvements**
  * Episode enclosure metadata (URL, file size, and MIME type) is now consistently stored in WordPress’s standard `url\\nsize\\nmime\\n` format when episodes are updated.

* **Tests**
  * Added coverage to ensure formatted enclosure values are written correctly across update and upgrade flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->