### PR TITLE
Action-bind the Castos webhook HMAC and reject replays (#859)

### DIFF
--- a/php/classes/rest/class-episodes-rest-controller.php
+++ b/php/classes/rest/class-episodes-rest-controller.php
@@ -167,7 +167,7 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 			return new \WP_Error( 'missing_signature', 'No signature or timestamp provided.', $status_401 );
 		}
 
-		if ( abs( time() - $timestamp ) > self::signature_freshness() ) {
+		if ( ! ctype_digit( (string) $timestamp ) || abs( time() - (int) $timestamp ) > self::signature_freshness() ) {
 			return new \WP_Error( 'invalid_timestamp', 'Invalid timestamp provided.', $status_401 );
 		}
 
@@ -182,7 +182,7 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 		// Require the action-bound nonce. Castos sends it for every authenticated request to
 		// SSP >= 3.16.2, so a missing nonce is never a legitimate request to this version.
 		if ( empty( $nonce ) ) {
-			return new \WP_Error( 'missing_nonce', 'No request nonce provided.', $status_401 );
+			return new \WP_Error( 'missing_nonce', 'Request signature invalid.', $status_401 );
 		}
 
 		$expected_signature = self::action_bound_signature( $request, $request_data, $timestamp, $nonce, $stored_key );
@@ -194,7 +194,7 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 		// Reject nonce reuse within the freshness window. Checked after signature verification so
 		// the nonce store can only ever hold values an attacker could not have forged.
 		if ( self::is_nonce_used( $nonce ) ) {
-			return new \WP_Error( 'replayed_nonce', 'Request nonce already used.', $status_401 );
+			return new \WP_Error( 'replayed_nonce', 'Request signature invalid.', $status_401 );
 		}
 
 		return true;
@@ -207,9 +207,12 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 	 * cannot be flooded with forged values. The TTL matches the signature
 	 * freshness window, after which the timestamp check rejects the request anyway.
 	 *
-	 * Backed by a transient: if an external object cache evicts the key before
-	 * its TTL, the residual risk is replay of the *same* request only — the
-	 * action binding (method/path/body) already prevents retargeting.
+	 * The first claim is atomic via wp_cache_add(), which fails if the key already
+	 * exists — closing the read-then-write race between concurrent replays on sites
+	 * with a persistent object cache. A transient provides the durable record (and
+	 * the store itself on sites without a persistent object cache, where wp_cache_add
+	 * is per-request only; there the residual replay is of the *same* request, which
+	 * the action binding already renders idempotent).
 	 *
 	 * @param string $nonce Per-request nonce header value.
 	 *
@@ -217,6 +220,10 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 	 */
 	protected static function is_nonce_used( $nonce ) {
 		$key = 'ssp_castos_nonce_' . md5( $nonce );
+
+		if ( ! wp_cache_add( $key, 1, 'ssp_castos_nonce', self::signature_freshness() ) ) {
+			return true;
+		}
 
 		if ( false !== get_transient( $key ) ) {
 			return true;

--- a/php/classes/rest/class-episodes-rest-controller.php
+++ b/php/classes/rest/class-episodes-rest-controller.php
@@ -147,8 +147,9 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 	/**
 	 * Validates Castos authentication headers.
 	 *
-	 * Checks if the request has valid Castos authentication headers (X-Castos-Signature and X-Castos-Timestamp)
-	 * and validates the signature against the stored API token.
+	 * Requires the action-bound headers (X-Castos-Signature, X-Castos-Timestamp, X-Castos-Nonce),
+	 * verifies the signature against the stored API token over the method/path/body/timestamp/nonce
+	 * canonical message, and rejects reused nonces.
 	 *
 	 * Static method for use in filters and other contexts.
 	 *
@@ -166,7 +167,7 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 			return new \WP_Error( 'missing_signature', 'No signature or timestamp provided.', $status_401 );
 		}
 
-		if ( abs( time() - $timestamp ) > 10 * MINUTE_IN_SECONDS ) {
+		if ( abs( time() - $timestamp ) > self::signature_freshness() ) {
 			return new \WP_Error( 'invalid_timestamp', 'Invalid timestamp provided.', $status_401 );
 		}
 
@@ -176,13 +177,107 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 			return new \WP_Error( 'no_api_key', 'Request signature invalid.', $status_401 );
 		}
 
-		$expected_signature = hash_hmac( 'sha256', json_encode( $request_data ) . $timestamp, $stored_key );
+		$nonce = $request->get_header( 'X-Castos-Nonce' );
+
+		// Require the action-bound nonce. Castos sends it for every authenticated request to
+		// SSP >= 3.16.2, so a missing nonce is never a legitimate request to this version.
+		if ( empty( $nonce ) ) {
+			return new \WP_Error( 'missing_nonce', 'No request nonce provided.', $status_401 );
+		}
+
+		$expected_signature = self::action_bound_signature( $request, $request_data, $timestamp, $nonce, $stored_key );
 
 		if ( ! hash_equals( $expected_signature, $signature ) ) {
 			return new \WP_Error( 'invalid_signature', 'Request signature invalid.', $status_401 );
 		}
 
+		// Reject nonce reuse within the freshness window. Checked after signature verification so
+		// the nonce store can only ever hold values an attacker could not have forged.
+		if ( self::is_nonce_used( $nonce ) ) {
+			return new \WP_Error( 'replayed_nonce', 'Request nonce already used.', $status_401 );
+		}
+
 		return true;
+	}
+
+	/**
+	 * Records a verified nonce and reports whether it was already seen.
+	 *
+	 * Only valid (signature-verified) nonces reach this point, so the store
+	 * cannot be flooded with forged values. The TTL matches the signature
+	 * freshness window, after which the timestamp check rejects the request anyway.
+	 *
+	 * Backed by a transient: if an external object cache evicts the key before
+	 * its TTL, the residual risk is replay of the *same* request only — the
+	 * action binding (method/path/body) already prevents retargeting.
+	 *
+	 * @param string $nonce Per-request nonce header value.
+	 *
+	 * @return bool True if the nonce was already used (replay), false on first use.
+	 */
+	protected static function is_nonce_used( $nonce ) {
+		$key = 'ssp_castos_nonce_' . md5( $nonce );
+
+		if ( false !== get_transient( $key ) ) {
+			return true;
+		}
+
+		set_transient( $key, 1, self::signature_freshness() );
+
+		return false;
+	}
+
+	/**
+	 * Returns the freshness window (in seconds) for Castos request timestamps and nonces.
+	 *
+	 * 5 minutes, per the Castos signer team's recommendation (no shorter than ~5 min) to
+	 * tolerate WordPress host clock skew. Replay is handled by the one-time nonce, so this
+	 * is a secondary guard rather than the primary defense.
+	 *
+	 * @return int
+	 */
+	protected static function signature_freshness() {
+		return 5 * MINUTE_IN_SECONDS;
+	}
+
+	/**
+	 * Builds the expected HMAC for the action-bound signature scheme.
+	 *
+	 * Binds the signature to the HTTP method, full request path (including the
+	 * REST prefix and any sub-directory), body, timestamp and per-request nonce,
+	 * matching the Castos client signer. The canonical message is
+	 * METHOD\nPATH\njson_body\ntimestamp\nnonce.
+	 *
+	 * PATH is reconstructed as the canonical `{home path}/{rest-prefix}{route}`
+	 * the Castos signer builds (it always signs the literal `/wp-json/` path),
+	 * rather than the raw request URI or `rest_url()`. This matches regardless of
+	 * the site's permalink structure, sub-directory install, or a reverse-proxy
+	 * path prefix.
+	 *
+	 * @param \WP_REST_Request $request      Full data about the request.
+	 * @param array            $request_data Request body used for signing.
+	 * @param string           $timestamp    Request timestamp header value.
+	 * @param string           $nonce        Per-request nonce header value.
+	 * @param string           $stored_key   Shared API token used as the HMAC secret.
+	 *
+	 * @return string Hex-encoded HMAC-SHA256 signature.
+	 */
+	protected static function action_bound_signature( $request, $request_data, $timestamp, $nonce, $stored_key ) {
+		$home_path = rtrim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+		$path      = $home_path . '/' . trim( rest_get_url_prefix(), '/' ) . $request->get_route();
+
+		$message = implode(
+			"\n",
+			array(
+				strtoupper( $request->get_method() ),
+				$path,
+				json_encode( $request_data ),
+				$timestamp,
+				$nonce,
+			)
+		);
+
+		return hash_hmac( 'sha256', $message, $stored_key );
 	}
 
 	/**

--- a/tests/WPUnit/EpisodesRestControllerCastosAuthTest.php
+++ b/tests/WPUnit/EpisodesRestControllerCastosAuthTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\WPUnit;
+
+use SeriouslySimplePodcasting\Rest\Episodes_Rest_Controller;
+
+/**
+ * Verifies Castos webhook signature authentication, including the action-bound
+ * signature scheme (CastosHQ/ssp-issues#859) and the retained legacy scheme.
+ *
+ * The action-bound signing format is mirrored from the Castos client
+ * (App\Services\SSP\SspRequestSigner): METHOD\nPATH\njson_body\ntimestamp\nnonce,
+ * where PATH is the path of rest_url() for the matched route.
+ */
+class EpisodesRestControllerCastosAuthTest extends \Codeception\TestCase\WPTestCase {
+
+	const TOKEN = 'secret-api-token';
+
+	const ROUTE = '/ssp/v1/episodes/123';
+
+	protected function setUp(): void {
+		parent::setUp();
+		update_option( 'ss_podcasting_podmotor_account_api_token', self::TOKEN );
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'ss_podcasting_podmotor_account_api_token' );
+		parent::tearDown();
+	}
+
+	/** A valid action-bound request authenticates. */
+	public function test_valid_action_bound_request_passes() {
+		$body    = array( 'file' => array( 'id' => 1 ) );
+		$request = $this->action_bound_request( 'PUT', self::ROUTE, $body, time(), $this->nonce() );
+
+		$this->assertTrue( Episodes_Rest_Controller::validate_castos_authentication( $request, $body ) );
+	}
+
+	/** An authenticated GET collection request with an empty body authenticates. */
+	public function test_action_bound_get_with_empty_body_passes() {
+		$request = $this->action_bound_request( 'GET', '/ssp/v1/episodes', array(), time(), $this->nonce() );
+
+		$this->assertTrue( Episodes_Rest_Controller::validate_castos_authentication( $request, array() ) );
+	}
+
+	/** Signature is bound to the HTTP method — a method mismatch is rejected. */
+	public function test_tampered_method_rejected() {
+		$body      = array( 'file' => array( 'id' => 1 ) );
+		$timestamp = time();
+		$nonce     = $this->nonce();
+		// Signed as GET, sent as PUT.
+		$signature = $this->action_bound_signature( 'GET', self::ROUTE, $body, $timestamp, $nonce );
+		$request   = $this->request( 'PUT', self::ROUTE, $body, $timestamp, $signature, $nonce );
+
+		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, $body ) );
+	}
+
+	/** Signature is bound to the request path — a path mismatch (retargeting) is rejected. */
+	public function test_tampered_path_rejected() {
+		$body      = array( 'file' => array( 'id' => 1 ) );
+		$timestamp = time();
+		$nonce     = $this->nonce();
+		// Signed for episode 123, replayed against episode 456.
+		$signature = $this->action_bound_signature( 'PUT', self::ROUTE, $body, $timestamp, $nonce );
+		$request   = $this->request( 'PUT', '/ssp/v1/episodes/456', $body, $timestamp, $signature, $nonce );
+
+		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, $body ) );
+	}
+
+	/** Signature is bound to the body — a body mismatch is rejected. */
+	public function test_tampered_body_rejected() {
+		$timestamp = time();
+		$nonce     = $this->nonce();
+		$signature = $this->action_bound_signature( 'PUT', self::ROUTE, array( 'file' => array( 'id' => 1 ) ), $timestamp, $nonce );
+		$tampered  = array( 'file' => array( 'id' => 999 ) );
+		$request   = $this->request( 'PUT', self::ROUTE, $tampered, $timestamp, $signature, $nonce );
+
+		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, $tampered ) );
+	}
+
+	/** An expired timestamp is rejected regardless of signature validity. */
+	public function test_expired_timestamp_rejected() {
+		$body    = array( 'file' => array( 'id' => 1 ) );
+		$request = $this->action_bound_request( 'PUT', self::ROUTE, $body, time() - 11 * MINUTE_IN_SECONDS, $this->nonce() );
+
+		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, $body ) );
+	}
+
+	/** A replayed nonce is rejected on the second use within the freshness window. */
+	public function test_replayed_nonce_rejected() {
+		$body      = array( 'file' => array( 'id' => 1 ) );
+		$timestamp = time();
+		$nonce     = $this->nonce();
+
+		$first = Episodes_Rest_Controller::validate_castos_authentication(
+			$this->action_bound_request( 'PUT', self::ROUTE, $body, $timestamp, $nonce ),
+			$body
+		);
+		$this->assertTrue( $first, 'First use of the nonce should authenticate' );
+
+		$second = Episodes_Rest_Controller::validate_castos_authentication(
+			$this->action_bound_request( 'PUT', self::ROUTE, $body, $timestamp, $nonce ),
+			$body
+		);
+		$this->assertWPError( $second, 'Replayed nonce should be rejected' );
+	}
+
+	/** A request without the X-Castos-Nonce header is rejected, even with an otherwise-valid action-bound signature. */
+	public function test_request_without_nonce_is_rejected() {
+		$body      = array( 'file' => array( 'id' => 1 ) );
+		$timestamp = time();
+		$nonce     = $this->nonce();
+		$signature = $this->action_bound_signature( 'PUT', self::ROUTE, $body, $timestamp, $nonce );
+		// Valid action-bound signature, but the nonce header is withheld.
+		$request = $this->request( 'PUT', self::ROUTE, $body, $timestamp, $signature, null );
+
+		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, $body ) );
+	}
+
+	private function nonce() {
+		return bin2hex( random_bytes( 32 ) );
+	}
+
+	/** Canonical `{home path}/{rest-prefix}{route}` — mirrors how the verifier and Castos signer derive PATH. */
+	private function route_path( $route ) {
+		$home_path = rtrim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+
+		return $home_path . '/' . trim( rest_get_url_prefix(), '/' ) . $route;
+	}
+
+	/** Builds the action-bound canonical message and HMAC, mirroring the Castos signer. */
+	private function action_bound_signature( $method, $route, $body, $timestamp, $nonce ) {
+		$message = implode( "\n", array( strtoupper( $method ), $this->route_path( $route ), json_encode( $body ), $timestamp, $nonce ) );
+
+		return hash_hmac( 'sha256', $message, self::TOKEN );
+	}
+
+	/** Builds a request carrying a valid action-bound signature for the given inputs. */
+	private function action_bound_request( $method, $route, $body, $timestamp, $nonce ) {
+		$signature = $this->action_bound_signature( $method, $route, $body, $timestamp, $nonce );
+
+		return $this->request( $method, $route, $body, $timestamp, $signature, $nonce );
+	}
+
+	/** Builds a WP_REST_Request with the given Castos auth headers ($nonce = null omits the nonce header). */
+	private function request( $method, $route, $body, $timestamp, $signature, $nonce ) {
+		$request = new \WP_REST_Request( $method, $route );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( json_encode( $body ) );
+		$request->set_header( 'X-Castos-Signature', $signature );
+		$request->set_header( 'X-Castos-Timestamp', $timestamp );
+		if ( null !== $nonce ) {
+			$request->set_header( 'X-Castos-Nonce', $nonce );
+		}
+
+		return $request;
+	}
+
+	private function assertWPError( $value, $message = '' ) {
+		$this->assertInstanceOf( '\WP_Error', $value, $message );
+	}
+}

--- a/tests/WPUnit/EpisodesRestControllerCastosAuthTest.php
+++ b/tests/WPUnit/EpisodesRestControllerCastosAuthTest.php
@@ -5,12 +5,12 @@ namespace Tests\WPUnit;
 use SeriouslySimplePodcasting\Rest\Episodes_Rest_Controller;
 
 /**
- * Verifies Castos webhook signature authentication, including the action-bound
- * signature scheme (CastosHQ/ssp-issues#859) and the retained legacy scheme.
+ * Verifies Castos webhook signature authentication via the action-bound
+ * signature scheme (CastosHQ/ssp-issues#859).
  *
  * The action-bound signing format is mirrored from the Castos client
  * (App\Services\SSP\SspRequestSigner): METHOD\nPATH\njson_body\ntimestamp\nnonce,
- * where PATH is the path of rest_url() for the matched route.
+ * where PATH is the canonical `{home path}/{rest-prefix}{route}`.
  */
 class EpisodesRestControllerCastosAuthTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/WPUnit/RestApiControllerTest.php
+++ b/tests/WPUnit/RestApiControllerTest.php
@@ -148,18 +148,26 @@ class RestApiControllerTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * Creates a WP_REST_Request with valid HMAC headers for the given token.
+	 * Creates a WP_REST_Request with valid action-bound HMAC headers for the given token.
+	 *
+	 * Mirrors the Castos signer: signs METHOD\nPATH\njson_body\ntimestamp\nnonce, where PATH
+	 * is the canonical `{home path}/{rest-prefix}{route}` the verifier reconstructs.
 	 *
 	 * @param string $api_token API token to sign with.
 	 *
 	 * @return \WP_REST_Request
 	 */
 	private function make_hmac_request( $api_token ) {
+		$route     = '/ssp/v1/status';
 		$timestamp = (string) time();
-		$signature = hash_hmac( 'sha256', json_encode( array() ) . $timestamp, $api_token );
+		$nonce     = bin2hex( random_bytes( 32 ) );
+		$path      = rtrim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' ) . '/' . trim( rest_get_url_prefix(), '/' ) . $route;
+		$message   = implode( "\n", array( 'GET', $path, json_encode( array() ), $timestamp, $nonce ) );
+		$signature = hash_hmac( 'sha256', $message, $api_token );
 
-		$request = new \WP_REST_Request( 'GET', '/ssp/v1/status' );
+		$request = new \WP_REST_Request( 'GET', $route );
 		$request->set_header( 'X-Castos-Timestamp', $timestamp );
+		$request->set_header( 'X-Castos-Nonce', $nonce );
 		$request->set_header( 'X-Castos-Signature', $signature );
 
 		return $request;


### PR DESCRIPTION
## Summary

This hardens how the plugin verifies the webhook requests Castos sends to a connected site (episode syncs, ad/campaign updates, connection checks).

Until now the request signature only covered the body and a timestamp. That left two gaps: a captured request could be **replayed**, or **re-pointed at a different episode or series** and still pass. This PR verifies a stronger signature and closes both.

- **The signature now covers the whole action.** It's checked against the HTTP method, the request path (including the episode/series id), the body, a timestamp, and a new one-time value (`X-Castos-Nonce`) — not just the body. A request can no longer be retargeted without breaking the signature.
- **Replays are rejected.** Each nonce works only once, and signed requests expire after 5 minutes.
- **Nonce is now required.** Requests without it are rejected; the old body-only signature is no longer accepted. Castos already sends the nonce to every site running 3.16.2+, so real traffic is unaffected.
- **Path matching is robust.** The path is rebuilt to match exactly what Castos signs, so verification works on subdirectory installs, custom permalinks, and behind a reverse proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened webhook authentication using action-bound request signatures.
  * Added nonce freshness and replay protection; requests with stale timestamps or reused nonces are rejected.
  * Improved signature validation across HTTP method, route, and request body (including empty-body GET requests).

* **Tests**
  * Added unit test coverage for valid authentication and multiple failure cases: tampered method, path, body, expired timestamp, missing nonce, and replayed nonce.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->