### PR TITLE
Gate cookie-auth elevation on a REST nonce; bind query into Castos HMAC

### DIFF
--- a/php/classes/rest/class-episodes-rest-controller.php
+++ b/php/classes/rest/class-episodes-rest-controller.php
@@ -251,9 +251,9 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 	 * Builds the expected HMAC for the action-bound signature scheme.
 	 *
 	 * Binds the signature to the HTTP method, full request path (including the
-	 * REST prefix and any sub-directory), body, timestamp and per-request nonce,
-	 * matching the Castos client signer. The canonical message is
-	 * METHOD\nPATH\njson_body\ntimestamp\nnonce.
+	 * REST prefix and any sub-directory), URL query, body, timestamp and per-request
+	 * nonce, matching the Castos client signer. The canonical message is
+	 * METHOD\nPATH\ncanonical_query\njson_body\ntimestamp\nnonce.
 	 *
 	 * PATH is reconstructed as the canonical `{home path}/{rest-prefix}{route}`
 	 * the Castos signer builds (it always signs the literal `/wp-json/` path),
@@ -278,6 +278,7 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 			array(
 				strtoupper( $request->get_method() ),
 				$path,
+				self::canonical_query( $request->get_query_params() ),
 				json_encode( $request_data ),
 				$timestamp,
 				$nonce,
@@ -285,6 +286,30 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 		);
 
 		return hash_hmac( 'sha256', $message, $stored_key );
+	}
+
+	/**
+	 * Canonicalizes the URL query so signer and verifier hash byte-for-byte identical bytes:
+	 * keys sorted, RFC3986 encoding (space as %20, not '+'), empty query collapses to ''.
+	 * Mirrors App\Services\SSP\SspRequestSigner::canonicalQuery() in the Castos backend.
+	 *
+	 * Every received query param is bound — including Castos's `castos-nonce` cache-buster.
+	 * Any param an attacker adds or alters on a signed GET therefore changes the signed
+	 * message and fails verification: the query is authenticated, never trusted from the
+	 * URL alone. Only flat params are signed (Castos never sends bracket/array notation).
+	 *
+	 * @param array $query Query parameters as received (WP_REST_Request::get_query_params()).
+	 *
+	 * @return string
+	 */
+	protected static function canonical_query( $query ) {
+		if ( empty( $query ) ) {
+			return '';
+		}
+
+		ksort( $query );
+
+		return http_build_query( $query, '', '&', PHP_QUERY_RFC3986 );
 	}
 
 	/**
@@ -511,6 +536,27 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Reports whether the request carries a valid WordPress REST nonce.
+	 *
+	 * Cookie-derived privilege (private statuses, unfiltered filter args) is granted only when
+	 * this passes, so a cross-site request that rides the login cookie without the nonce cannot
+	 * elevate. @wordpress/api-fetch sends the nonce (X-WP-Nonce) for block-editor callers.
+	 *
+	 * @param \WP_REST_Request $request Full data about the request.
+	 *
+	 * @return bool
+	 */
+	protected static function has_valid_rest_nonce( $request ) {
+		$nonce = $request->get_header( 'X-WP-Nonce' );
+
+		if ( empty( $nonce ) ) {
+			$nonce = $request->get_param( '_wpnonce' );
+		}
+
+		return ! empty( $nonce ) && (bool) wp_verify_nonce( $nonce, 'wp_rest' );
+	}
+
+	/**
 	 * Get a collection of items
 	 *
 	 * @param \WP_REST_Request $request Full data about the request.
@@ -518,9 +564,13 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		// WordPress REST API resets current user to 0 if no nonce is provided (CSRF protection)
-		// Manually authenticate from cookie if present to allow logged-in users to access their content
-		Rest_Api_Controller::authenticate_user_from_cookie();
+		// WordPress REST API resets the current user to 0 when a cookie request arrives without a
+		// valid REST nonce (CSRF protection). Only restore that identity when a valid nonce is
+		// present — otherwise the request stays public. Block-editor callers use
+		// @wordpress/api-fetch, which sends X-WP-Nonce, so legitimate editor use is unaffected.
+		if ( self::has_valid_rest_nonce( $request ) ) {
+			Rest_Api_Controller::authenticate_user_from_cookie();
+		}
 
 		// Check if request has valid Castos authentication (optional for GET requests)
 		$castos_authenticated = true === static::validate_castos_authentication( $request, array() );

--- a/php/classes/rest/class-episodes-rest-controller.php
+++ b/php/classes/rest/class-episodes-rest-controller.php
@@ -553,7 +553,13 @@ class Episodes_Rest_Controller extends WP_REST_Controller {
 			$nonce = $request->get_param( '_wpnonce' );
 		}
 
-		return ! empty( $nonce ) && (bool) wp_verify_nonce( $nonce, 'wp_rest' );
+		// A malformed request can supply a non-scalar _wpnonce (e.g. `?_wpnonce[]=x`);
+		// wp_verify_nonce() would choke on it, so treat anything non-scalar as no nonce.
+		if ( empty( $nonce ) || ! is_scalar( $nonce ) ) {
+			return false;
+		}
+
+		return (bool) wp_verify_nonce( $nonce, 'wp_rest' );
 	}
 
 	/**

--- a/tests/WPUnit/EpisodesRestControllerCastosAuthTest.php
+++ b/tests/WPUnit/EpisodesRestControllerCastosAuthTest.php
@@ -6,11 +6,13 @@ use SeriouslySimplePodcasting\Rest\Episodes_Rest_Controller;
 
 /**
  * Verifies Castos webhook signature authentication via the action-bound
- * signature scheme (CastosHQ/ssp-issues#859).
+ * signature scheme (CastosHQ/ssp-issues#859, #858).
  *
  * The action-bound signing format is mirrored from the Castos client
- * (App\Services\SSP\SspRequestSigner): METHOD\nPATH\njson_body\ntimestamp\nnonce,
- * where PATH is the canonical `{home path}/{rest-prefix}{route}`.
+ * (App\Services\SSP\SspRequestSigner):
+ * METHOD\nPATH\ncanonical_query\njson_body\ntimestamp\nnonce, where PATH is the
+ * canonical `{home path}/{rest-prefix}{route}` and canonical_query is the ksort'd,
+ * RFC3986-encoded query string ('' when empty).
  */
 class EpisodesRestControllerCastosAuthTest extends \Codeception\TestCase\WPTestCase {
 
@@ -117,6 +119,73 @@ class EpisodesRestControllerCastosAuthTest extends \Codeception\TestCase\WPTestC
 		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, $body ) );
 	}
 
+	/** An authenticated GET carrying real query params authenticates when the query is signed. */
+	public function test_action_bound_get_with_query_passes() {
+		$query   = array( 'per_page' => 25, 'page' => 2, 'castos-nonce' => 1700000000 );
+		$request = $this->action_bound_request( 'GET', '/ssp/v1/podcasts/42/episodes', array(), time(), $this->nonce(), $query );
+
+		$this->assertTrue( Episodes_Rest_Controller::validate_castos_authentication( $request, array() ) );
+	}
+
+	/** Signature is bound to the query — mutating a signed query value is rejected. */
+	public function test_tampered_query_value_rejected() {
+		$timestamp = time();
+		$nonce     = $this->nonce();
+		$signature = $this->action_bound_signature( 'GET', '/ssp/v1/podcasts/42/episodes', array(), $timestamp, $nonce, array( 'per_page' => 25, 'page' => 2 ) );
+		// Signed page=2, sent page=99.
+		$request   = $this->request( 'GET', '/ssp/v1/podcasts/42/episodes', array(), $timestamp, $signature, $nonce, array( 'per_page' => 25, 'page' => 99 ) );
+
+		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, array() ) );
+	}
+
+	/** An on-path attacker injecting an authority-bearing query param onto a signed GET is rejected. */
+	public function test_injected_authority_query_param_rejected() {
+		$timestamp = time();
+		$nonce     = $this->nonce();
+		$signed    = array( 'per_page' => 25, 'page' => 2 );
+		$signature = $this->action_bound_signature( 'GET', '/ssp/v1/podcasts/42/episodes', array(), $timestamp, $nonce, $signed );
+		// Attacker appends filter[post_status]=private, which the signer never covered.
+		$tampered  = $signed + array( 'filter' => array( 'post_status' => 'private' ) );
+		$request   = $this->request( 'GET', '/ssp/v1/podcasts/42/episodes', array(), $timestamp, $signature, $nonce, $tampered );
+
+		$this->assertWPError( Episodes_Rest_Controller::validate_castos_authentication( $request, array() ) );
+	}
+
+	/** Query key order is irrelevant — both sides ksort before signing. */
+	public function test_query_binding_is_order_independent() {
+		$timestamp = time();
+		$nonce     = $this->nonce();
+		// Sign one key order...
+		$signature = $this->action_bound_signature( 'GET', '/ssp/v1/podcasts/42/episodes', array(), $timestamp, $nonce, array( 'page' => 2, 'per_page' => 25 ) );
+		// ...send the reverse order; the ksort on both sides makes the signature still match.
+		$request   = $this->request( 'GET', '/ssp/v1/podcasts/42/episodes', array(), $timestamp, $signature, $nonce, array( 'per_page' => 25, 'page' => 2 ) );
+
+		$this->assertTrue( Episodes_Rest_Controller::validate_castos_authentication( $request, array() ) );
+	}
+
+	/**
+	 * Cross-repo pin shared with App\Services\SSP\SspRequestSignerTest::test_golden_vector_matches_the_shared_canonical_form.
+	 * Any drift in the canonical form (key sorting, RFC3986 encoding, segment order) on either
+	 * side breaks this identical vector.
+	 */
+	public function test_golden_vector_matches_the_shared_canonical_form() {
+		$expected = 'f8fea0761219ff3f6fd9b997ac0571612f5fa222b39dfa3d2e9130c794e3e238';
+
+		$message = implode(
+			"\n",
+			array(
+				'GET',
+				'/wp-json/ssp/v1/podcasts/42/episodes',
+				'castos-nonce=1700000000&page=2&per_page=25',
+				json_encode( array() ),
+				1700000000,
+				'golden-nonce',
+			)
+		);
+
+		$this->assertSame( $expected, hash_hmac( 'sha256', $message, self::TOKEN ) );
+	}
+
 	private function nonce() {
 		return bin2hex( random_bytes( 32 ) );
 	}
@@ -128,25 +197,39 @@ class EpisodesRestControllerCastosAuthTest extends \Codeception\TestCase\WPTestC
 		return $home_path . '/' . trim( rest_get_url_prefix(), '/' ) . $route;
 	}
 
+	/** Canonicalizes the query the way both the Castos signer and the verifier do (ksort + RFC3986, '' when empty). */
+	private function canonical_query( $query ) {
+		if ( empty( $query ) ) {
+			return '';
+		}
+
+		ksort( $query );
+
+		return http_build_query( $query, '', '&', PHP_QUERY_RFC3986 );
+	}
+
 	/** Builds the action-bound canonical message and HMAC, mirroring the Castos signer. */
-	private function action_bound_signature( $method, $route, $body, $timestamp, $nonce ) {
-		$message = implode( "\n", array( strtoupper( $method ), $this->route_path( $route ), json_encode( $body ), $timestamp, $nonce ) );
+	private function action_bound_signature( $method, $route, $body, $timestamp, $nonce, $query = array() ) {
+		$message = implode( "\n", array( strtoupper( $method ), $this->route_path( $route ), $this->canonical_query( $query ), json_encode( $body ), $timestamp, $nonce ) );
 
 		return hash_hmac( 'sha256', $message, self::TOKEN );
 	}
 
 	/** Builds a request carrying a valid action-bound signature for the given inputs. */
-	private function action_bound_request( $method, $route, $body, $timestamp, $nonce ) {
-		$signature = $this->action_bound_signature( $method, $route, $body, $timestamp, $nonce );
+	private function action_bound_request( $method, $route, $body, $timestamp, $nonce, $query = array() ) {
+		$signature = $this->action_bound_signature( $method, $route, $body, $timestamp, $nonce, $query );
 
-		return $this->request( $method, $route, $body, $timestamp, $signature, $nonce );
+		return $this->request( $method, $route, $body, $timestamp, $signature, $nonce, $query );
 	}
 
 	/** Builds a WP_REST_Request with the given Castos auth headers ($nonce = null omits the nonce header). */
-	private function request( $method, $route, $body, $timestamp, $signature, $nonce ) {
+	private function request( $method, $route, $body, $timestamp, $signature, $nonce, $query = array() ) {
 		$request = new \WP_REST_Request( $method, $route );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body( json_encode( $body ) );
+		if ( ! empty( $query ) ) {
+			$request->set_query_params( $query );
+		}
 		$request->set_header( 'X-Castos-Signature', $signature );
 		$request->set_header( 'X-Castos-Timestamp', $timestamp );
 		if ( null !== $nonce ) {

--- a/tests/WPUnit/EpisodesRestControllerTest.php
+++ b/tests/WPUnit/EpisodesRestControllerTest.php
@@ -10,6 +10,103 @@ class EpisodesRestControllerTest extends \Codeception\TestCase\WPTestCase {
 		parent::setUp();
 	}
 
+	protected function tearDown(): void {
+		unset( $_COOKIE[ LOGGED_IN_COOKIE ] );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * The nonce gate grants cookie-derived privilege only for a valid wp_rest nonce.
+	 */
+	public function testHasValidRestNonceOnlyAcceptsValidNonce() {
+		$editor = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $editor );
+
+		$method = new \ReflectionMethod( Episodes_Rest_Controller::class, 'has_valid_rest_nonce' );
+		$method->setAccessible( true );
+
+		$missing = new \WP_REST_Request( 'GET', '/ssp/v1/episodes' );
+		$this->assertFalse( $method->invoke( null, $missing ), 'No nonce must not grant privilege' );
+
+		$invalid = new \WP_REST_Request( 'GET', '/ssp/v1/episodes' );
+		$invalid->set_header( 'X-WP-Nonce', 'not-a-real-nonce' );
+		$this->assertFalse( $method->invoke( null, $invalid ), 'An invalid nonce must not grant privilege' );
+
+		$valid = new \WP_REST_Request( 'GET', '/ssp/v1/episodes' );
+		$valid->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
+		$this->assertTrue( $method->invoke( null, $valid ), 'A valid wp_rest nonce must grant privilege' );
+	}
+
+	/**
+	 * A logged-in cookie without a REST nonce must not expose private episodes (the CSRF gap).
+	 */
+	public function testGetItemsWithoutNonceHidesPrivateEpisodes() {
+		$user    = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$publish = $this->create_episode( 'publish', $user );
+		$private = $this->create_episode( 'private', $user );
+
+		// Logged-in browser cookie present, but no REST nonce accompanies the request.
+		$_COOKIE[ LOGGED_IN_COOKIE ] = wp_generate_auth_cookie( $user, time() + HOUR_IN_SECONDS, 'logged_in' );
+		wp_set_current_user( 0 );
+
+		$ids = $this->get_items_ids();
+
+		$this->assertContains( $publish, $ids, 'Published episode should be listed' );
+		$this->assertNotContains( $private, $ids, 'Private episode must not leak without a valid REST nonce' );
+	}
+
+	/**
+	 * A privileged user with a valid REST nonce still sees private episodes (no editor regression).
+	 */
+	public function testGetItemsWithValidNonceShowsPrivateEpisodes() {
+		$user = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		// A valid nonce is bound to the resolved user, exactly as core keeps the cookie user
+		// when @wordpress/api-fetch sends X-WP-Nonce.
+		wp_set_current_user( $user );
+		$nonce = wp_create_nonce( 'wp_rest' );
+
+		$publish = $this->create_episode( 'publish', $user );
+		$private = $this->create_episode( 'private', $user );
+
+		$ids = $this->get_items_ids( array( 'X-WP-Nonce' => $nonce ) );
+
+		$this->assertContains( $publish, $ids );
+		$this->assertContains( $private, $ids, 'A privileged user with a valid nonce should see private episodes' );
+	}
+
+	private function create_episode( $status, $author ) {
+		return self::factory()->post->create(
+			array(
+				'post_type'   => SSP_CPT_PODCAST,
+				'post_status' => $status,
+				'post_author' => $author,
+			)
+		);
+	}
+
+	/** Calls get_items() with the given headers and returns the listed episode IDs. */
+	private function get_items_ids( $headers = array() ) {
+		$request = new \WP_REST_Request( 'GET', '/ssp/v1/episodes' );
+		$request->set_param( 'per_page', 10 );
+		$request->set_param( 'page', 1 );
+
+		foreach ( $headers as $key => $value ) {
+			$request->set_header( $key, $value );
+		}
+
+		$response = $this->make_controller()->get_items( $request );
+
+		$ids = array();
+		foreach ( (array) $response->get_data() as $item ) {
+			if ( isset( $item['id'] ) ) {
+				$ids[] = $item['id'];
+			}
+		}
+
+		return $ids;
+	}
+
 	/**
 	 * Test that the filter parameter cannot override post_status for unauthenticated requests.
 	 */

--- a/tests/WPUnit/EpisodesRestControllerTest.php
+++ b/tests/WPUnit/EpisodesRestControllerTest.php
@@ -33,6 +33,10 @@ class EpisodesRestControllerTest extends \Codeception\TestCase\WPTestCase {
 		$invalid->set_header( 'X-WP-Nonce', 'not-a-real-nonce' );
 		$this->assertFalse( $method->invoke( null, $invalid ), 'An invalid nonce must not grant privilege' );
 
+		$non_scalar = new \WP_REST_Request( 'GET', '/ssp/v1/episodes' );
+		$non_scalar->set_param( '_wpnonce', array( 'x' ) );
+		$this->assertFalse( $method->invoke( null, $non_scalar ), 'A non-scalar _wpnonce must not grant privilege' );
+
 		$valid = new \WP_REST_Request( 'GET', '/ssp/v1/episodes' );
 		$valid->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
 		$this->assertTrue( $method->invoke( null, $valid ), 'A valid wp_rest nonce must grant privilege' );

--- a/tests/WPUnit/RestApiControllerTest.php
+++ b/tests/WPUnit/RestApiControllerTest.php
@@ -150,8 +150,9 @@ class RestApiControllerTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Creates a WP_REST_Request with valid action-bound HMAC headers for the given token.
 	 *
-	 * Mirrors the Castos signer: signs METHOD\nPATH\njson_body\ntimestamp\nnonce, where PATH
-	 * is the canonical `{home path}/{rest-prefix}{route}` the verifier reconstructs.
+	 * Mirrors the Castos signer: signs METHOD\nPATH\ncanonical_query\njson_body\ntimestamp\nnonce,
+	 * where PATH is the canonical `{home path}/{rest-prefix}{route}` the verifier reconstructs and
+	 * canonical_query is '' here (the status request carries no query params).
 	 *
 	 * @param string $api_token API token to sign with.
 	 *
@@ -162,7 +163,7 @@ class RestApiControllerTest extends \Codeception\TestCase\WPTestCase {
 		$timestamp = (string) time();
 		$nonce     = bin2hex( random_bytes( 32 ) );
 		$path      = rtrim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' ) . '/' . trim( rest_get_url_prefix(), '/' ) . $route;
-		$message   = implode( "\n", array( 'GET', $path, json_encode( array() ), $timestamp, $nonce ) );
+		$message   = implode( "\n", array( 'GET', $path, '', json_encode( array() ), $timestamp, $nonce ) );
 		$signature = hash_hmac( 'sha256', $message, $api_token );
 
 		$request = new \WP_REST_Request( 'GET', $route );


### PR DESCRIPTION
## Summary

The episodes REST endpoint could hand back private and draft episodes to a logged-in user's browser session even when the request didn't carry a REST nonce. That's the CSRF gap flagged in the security scan (#858) — a malicious site could ride a signed-in editor's cookie and pull content they shouldn't see.

This change makes the endpoint trust a browser session only when a valid nonce comes with it. No nonce, no elevation — the request is treated as public and only published episodes come back. The block editor already sends the nonce automatically, so nothing changes for editors doing real work.

While we were in here, we also closed a related gap on the Castos side: query parameters on a signed request are now covered by the signature, so they can't be tampered with in transit to expose private content.

## What this delivers

- Private and draft episodes stay hidden from cookie requests that don't present a valid REST nonce.
- Unauthenticated visitors still get published episodes only — no change.
- Logged-in editors still see their private and draft episodes in the block editor.
- Castos-authenticated requests are unaffected for legitimate traffic; tampered-with query parameters no longer slip through.
- Test coverage for each of the above.

## Heads up — ships with Castos

The query-signature half of this depends on a matching change in the Castos app that hasn't landed yet. This branch must not be merged or deployed until that change is live, otherwise Castos will stop seeing private and draft episodes during sync. Hold the merge until both are ready.

## How to verify

- A signed-in editor still sees private and draft episodes in the block editor.
- A logged-out visitor hitting the episodes endpoint gets published episodes only.
- After the Castos change is live, confirm Castos sync still pulls private and draft episodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request signature validation by canonicalizing URL query parameters (stable ordering and RFC3986-safe encoding), reducing signature mismatches and tampering risk.
  * Tightened authenticated episode listing behavior: private episodes are now returned only when a valid REST nonce is present and correctly formatted (missing/invalid values are treated as unauthenticated).
* **Tests**
  * Added/updated test coverage for query signing, tampered query rejection, injected authority parameter rejection, query order independence, and golden-vector verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->