### PR TITLE
Fix Select2 multi-select styling on integration settings page #863

### DIFF
--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -502,6 +502,19 @@ input:focus + .ssp-toggle__slider {
 body.ssp-admin {
   --wp-admin-theme-color: #853AED;
 }
+body.ssp-admin .select2-container--default .select2-selection--multiple {
+  overflow: visible;
+  min-height: 2.5rem;
+}
+body.ssp-admin .select2-container--default .select2-selection--multiple .select2-selection__rendered {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  line-height: 1.5rem;
+}
+body.ssp-admin .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  padding-right: 8px;
+}
 
 .ssp-admin {
   background-color: #F1F5F9;

--- a/assets/admin/scss/_ssp-admin.scss
+++ b/assets/admin/scss/_ssp-admin.scss
@@ -2,6 +2,26 @@
 
 body.ssp-admin {
 	--wp-admin-theme-color: #{$clr_purple_600};
+
+	// Select2 4.1.0-rc.0 renders the chip list as `display: inline` with a
+	// scrolling parent, so chips spill outside the box and align to the bottom.
+	// Make the list a wrapping flexbox so the box grows with its content and
+	// the chips + search cursor stay vertically centered.
+	.select2-container--default .select2-selection--multiple {
+		overflow: visible;
+		min-height: 2.5rem;
+
+		.select2-selection__rendered {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+			line-height: 1.5rem;
+		}
+
+		.select2-selection__choice {
+			padding-right: 8px;
+		}
+	}
 }
 
 .ssp-admin {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -339,7 +339,7 @@ jQuery(document).ready(function($) {
 		$('.' + $(this).data('preview')).attr('src', '').trigger('change');
 	});
 
-	$('.js-ssp-select2').select2();
+	$('.js-ssp-select2').select2({ width: '100%' });
 
 	/**
 	* Provides possibility to dynamically change the dynamo URL when the episode title or episode podcast is changed.


### PR DESCRIPTION
## Summary

The Select2 multi-select fields on the Podcast Settings Integrations page render poorly. The box is narrow, shows a permanent scrollbar, chips overflow outside the border, and the search cursor sits below the selected items instead of aligned with them.

## Requirements

- Multi-select fields should span the full width of the settings form.
- The selection box should not show a permanent scrollbar.
- The box should grow vertically to fit selected items as they wrap onto new lines.
- Selected item chips and the search cursor should be vertically centered within the box.
- Selected chips should have adequate horizontal spacing.
- Styling changes must be scoped to the SSP settings pages only, with no impact on other admin pages, other plugins, or the frontend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of multi-select fields in the admin area so selected items wrap cleanly, stay visible, and have better spacing.
  * Ensured Select2 fields consistently expand to fill the available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->